### PR TITLE
fix, bestiary, adult red dragon, removed redundant lair actions

### DIFF
--- a/data/bestiary/bestiary-mm.json
+++ b/data/bestiary/bestiary-mm.json
@@ -1262,18 +1262,6 @@
 					"attack": [
 						"Fire Breath||18d6"
 					]
-				},
-				{
-					"name": "Lair Actions",
-					"text": [
-						"On initiative count 20 (losing initiative ties), the dragon takes a lair action to cause one of the following effects: the dragon can't use the same effect two rounds in a row:",
-						"• Magma erupts from a point on the ground the dragon can see within 120 feet of it, creating a 20-foot-high, 5-foot-radius geyser. Each creature in the geyser's area must make a DC 15 Dexterity saving throw, taking 21 (6d6) fire damage on a failed save, or half as much damage on a successful one.",
-						"• A tremor shakes the lair in a 60-foot-radius around the dragon. Each creature other than the dragon on the ground in that area must succeed on a DC 15 Dexterity saving throw or be knocked prone.",
-						"• Volcanic gases form a cloud in a 20-foot-radius sphere centered on a point the dragon can see within 120 feet of it. The sphere spreads around corners, and its area is lightly obscured. It lasts until initiative count 20 on the next round. Each creature that starts its turn in the cloud must succeed on a DC 13 Constitution saving throw or be poisoned until the end of its turn. While poisoned in this way, a creature is incapacitated."
-					],
-					"attack": [
-						"Magma Eruption||6d6"
-					]
 				}
 			],
 			"legendaryGroup": "Red Dragon",


### PR DESCRIPTION
The adult red dragon still had Lair Actions listed has ordinary actions,
in addition to the "new format" recently added for them.