### PR TITLE
Bestiary, MM, Drow Variant FIX

### DIFF
--- a/data/bestiary/bestiary-mm.json
+++ b/data/bestiary/bestiary-mm.json
@@ -8355,9 +8355,7 @@
 							"type": "entries",
 							"entries": [
 								"Drow often wear magic armor and carry magic weapons that lose their enhancement bonuses permanently if they are exposed to sunlight for 1 hour or longer.",
-								"A {@creature drow} wearing a {@item chain shirt +1|dmg|+1 chain shirt} and carrying a {@item shortsword +1|dmg|+1 shortsword} has AC 19 and a +1 bonus on attack and damage rolls with shortsword attacks.",
-								"A {@creature drow elite warrior} wearing {@item studded leather armor +2|dmg|+2 studded leather} and carrying a {@item shortsword +2|dmg|+2 shortsword} has AC 20 and a +2 bonus on attack and damage rolls with shortsword attacks.",
-								"A {@creature drow priestess of lolth} wearing {@item scale mail +3|dmg|+3 scale mail} has AC 19."
+								"A {@creature drow} wearing a {@item chain shirt +1|dmg|+1 chain shirt} and carrying a {@item shortsword +1|dmg|+1 shortsword} has AC 16 and a +1 bonus on attack and damage rolls with shortsword attacks."
 							]
 						}
 					]
@@ -8451,6 +8449,21 @@
 				}
 			],
 			"spells": "dancing lights, darkness, faerie fire, levitate",
+			"variant": [
+				{
+					"type": "variant",
+					"name": "Drow Magic Armor and Weapons",
+					"entries": [
+						{
+							"type": "entries",
+							"entries": [
+								"Drow often wear magic armor and carry magic weapons that lose their enhancement bonuses permanently if they are exposed to sunlight for 1 hour or longer.",
+								"A {@creature drow elite warrior} wearing {@item studded leather armor +2|dmg|+2 studded leather} and carrying a {@item shortsword +2|dmg|+2 shortsword} has AC 20 and a +2 bonus on attack and damage rolls with shortsword attacks."
+							]
+						}
+					]
+				}
+			],
 			"page": 128
 		},
 		{
@@ -8627,6 +8640,21 @@
 				}
 			],
 			"spells": "dancing lights, darkness, faerie fire, levitate, guidance, poison spray, resistance, spare the dying, thaumaturgy, animal friendship, cure wounds, detect poison and disease, ray of sickness, lesser restoration, protection from poison, web, conjure animals, dispel magic, divination, freedom of movement, insect plague, mass cure wounds",
+			"variant": [
+				{
+					"type": "variant",
+					"name": "Drow Magic Armor and Weapons",
+					"entries": [
+						{
+							"type": "entries",
+							"entries": [
+								"Drow often wear magic armor and carry magic weapons that lose their enhancement bonuses permanently if they are exposed to sunlight for 1 hour or longer.",
+								"A {@creature drow priestess of lolth} wearing {@item scale mail +3|dmg|+3 scale mail} has AC 19."
+							]
+						}
+					]
+				}
+			],
 			"page": 129
 		},
 		{


### PR DESCRIPTION
The AC of a **Drow** with +1 armor is 16, not 19
(this is wrong also in the MM and was never "errataed").

Added the variant field (?) also to **Drow Elite Warrior** and **Drow Priestess of Lolth**,
and now each one of them (basic Drow included) only has its own respective variant.