### PR TITLE
[Fix] Bestiary, Myconid Sovereign

### DIFF
--- a/data/bestiary/bestiary-mm.json
+++ b/data/bestiary/bestiary-mm.json
@@ -19234,7 +19234,7 @@
 					]
 				},
 				{
-					"name": "Animating Spores",
+					"name": "Animating Spores (3/Day)",
 					"entries": [
 						"The myconid targets one corpse of a humanoid or a Large or smaller beast within 5 feet of it and releases spores at the corpse. In 24 hours, the corpse rises as a spore servant. The corpse stays animated for 1d4+1 weeks or until destroyed, and it can't be animated again in this way."
 					]


### PR DESCRIPTION
Was "Animating Spores", changed to "Animating Spores **(3/Day)**" (MM page 232)