### PR TITLE
Items, Minor Fixes

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -11080,7 +11080,7 @@
 			"entries": [
 				"Created by the stone giant librarians of Gravenhollow, this nineteen-inch-long shard of quartz grants you advantage on Intelligence ({@skill Investigation}) checks while it is on your person.",
 				"The crystal has 10 charges. While holding it, you can use an action to expend some of its charges to cast one of the following spells from it: {@spell speak with animals} (2 charges), {@spell speak with dead} (4 charges), or {@spell speak with plants} (3 charges).",
-				"When you cast a {@spell divination} spell, you can use the crystal in place of one material component that would normally be consumed by the spell, at a cost of 1 charge per level of the spell. The crystal is not consumed when used in this way.",
+				"When you cast a {@filter divination|spells|school=D} spell, you can use the crystal in place of one material component that would normally be consumed by the spell, at a cost of 1 charge per level of the spell. The crystal is not consumed when used in this way.",
 				"The crystal regains 1d6+4 expended charges daily at dawn. If you expend the crystal's last charge, roll a d20. On a 1, the crystal vanishes, lost forever."
 			]
 		},

--- a/data/items.json
+++ b/data/items.json
@@ -7894,7 +7894,7 @@
 			"page": 184,
 			"reqAttune": "by a Spellcaster",
 			"entries": [
-				"While this pearl is on your person, you can use an action to speak its command word and regain one expended spell slot. If the expended slot of of 4th level or higher, the new slot is 3rd level. Once you have used the pearl, it can't be used again until the next dawn."
+				"While this pearl is on your person, you can use an action to speak its command word and regain one expended spell slot. If the expended slot was of 4th level or higher, the new slot is 3rd level. Once you have used the pearl, it can't be used again until the next dawn."
 			]
 		},
 		{

--- a/data/items.json
+++ b/data/items.json
@@ -5309,7 +5309,7 @@
 			"page": 172,
 			"reqAttune": "YES",
 			"entries": [
-				"These gloves seem to almost meld into your hands when you don them. When a ranged weapon attack hits you while you're wearing them, you can use your reaction to reduce the damage by 1d10 + your Dexterity modifier. provided that you have a free hand. If you reduce the damage to 0, you can catch the missile if it is small enough for you to hold in that hand."
+				"These gloves seem to almost meld into your hands when you don them. When a ranged weapon attack hits you while you're wearing them, you can use your reaction to reduce the damage by 1d10 + your Dexterity modifier, provided that you have a free hand. If you reduce the damage to 0, you can catch the missile if it is small enough for you to hold in that hand."
 			]
 		},
 		{


### PR DESCRIPTION
Pearl of Power, "of of" to "was of".

Also minor fix (comma instead of period) in Gloves of Missile Snaring.

Stonespeaker crystal: It now links to the Spells List (filtered by school) and not to the Divination spell.