### PR TITLE
book-phb.json, missing punctuation symbol

### DIFF
--- a/data/book/book-phb.json
+++ b/data/book/book-phb.json
@@ -7997,7 +7997,7 @@
 							"type": "entries",
 							"name": "Spell Level",
 							"entries": [
-								"Every spell has a level from 0 to 9. A spell's level is a general indicator of how powerful it is, with the lowly (but still impressive) magic missile at 1st level and the incredible time stop at 9th. Cantrips\u2014simple but powerful spells that characters can cast almost by rote are level 0. The higher a spell's level, the higher level a spellcaster must be to use that spell.",
+								"Every spell has a level from 0 to 9. A spell's level is a general indicator of how powerful it is, with the lowly (but still impressive) magic missile at 1st level and the incredible time stop at 9th. Cantrips\u2014simple but powerful spells that characters can cast almost by rote\u2014are level 0. The higher a spell's level, the higher level a spellcaster must be to use that spell.",
 								"Spell level and character level don't correspond directly. Typically, a character has to be at least 17th level, not 9th level, to cast a 9th-level spell."
 							]
 						},


### PR DESCRIPTION
Normally I'd use a blank before and after that symbol (-), but I've checked in the PHB
and they are not used (except when the following word goes to next line, but
we can't predict that with web pages).