### PR TITLE
Bestiary, MM, links to summoned creatures and myconid variant features from OotA

### DIFF
--- a/data/bestiary/bestiary-mm.json
+++ b/data/bestiary/bestiary-mm.json
@@ -50,7 +50,7 @@
 				{
 					"name": "Summon Air Elemental",
 					"entries": [
-						"Five aarakocra within 30 feet of each other can magically summon an air elemental. Each of the five must use its action and movement on three consecutive turns to perform an aerial dance and must maintain concentration while doing so (as if concentrating on a spell). When all five have finished their third turn of the dance, the elemental appears in an unoccupied space within 60 feet of them. It is friendly toward them and obeys their spoken commands. It remains for 1 hour, until it or all its summoners die, or until any of its summoners dismisses it as a bonus action. A summoner can't perform the dance again until it finishes a short rest. When the elemental returns to the Elemental Plane of Air, any aarakocra within 5 feet of it can return with it."
+						"Five aarakocra within 30 feet of each other can magically summon an {@creature air elemental}. Each of the five must use its action and movement on three consecutive turns to perform an aerial dance and must maintain concentration while doing so (as if concentrating on a spell). When all five have finished their third turn of the dance, the elemental appears in an unoccupied space within 60 feet of them. It is friendly toward them and obeys their spoken commands. It remains for 1 hour, until it or all its summoners die, or until any of its summoners dismisses it as a bonus action. A summoner can't perform the dance again until it finishes a short rest. When the elemental returns to the Elemental Plane of Air, any aarakocra within 5 feet of it can return with it."
 					]
 				}
 			],
@@ -3008,7 +3008,7 @@
 					"name": "Variant: Summon Yugoloth (1/Day)",
 					"entries": [
 						"The yugoloth attempts a magical summoning.",
-						"An arcanaloth has a 40 percent chance of summoning one arcanaloth.",
+						"An arcanaloth has a {@chance 40|40 percent|40% summoning chance} chance of summoning one arcanaloth.",
 						"A summoned yugoloth appears in an unoccupied space within 60 feet of its summoner, does as it pleases, and can't summon other yugoloths. The summoned yugoloth remains for 1 minute, until it or its summoner dies, or until its summoner takes a bonus action to dismiss it."
 					]
 				}
@@ -3619,7 +3619,7 @@
 					"name": "Variant: Summon Demon (1/Day)",
 					"entries": [
 						"The demon chooses what to summon and attempts a magical summoning.",
-						"A balor has a 50 percent chance of summoning 1d8 vrocks, 1d6 hezrous, 1d4 glabrezus, 1d3 nalfeshnees, 1d2 mariliths, or one goristro.",
+						"A balor has a {@chance 50|50 percent|50% summoning chance} chance of summoning 1d8 {@creature vrock}s, 1d6 {@creature hezrou}s, 1d4 {@creature glabrezu}s, 1d3 {@creature nalfeshnee}s, 1d2 {@creature marilith}s, or one {@creature goristro}.",
 						"A summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
 					]
 				}
@@ -3932,7 +3932,7 @@
 					"name": "Variant: Summon Demon (1/Day)",
 					"entries": [
 						"The demon chooses what to summon and attempts a magical summoning.",
-						"A barlgura has a 30 percent chance of summoning one barlgura.",
+						"A barlgura has a {@chance 30|30 percent|30% summoning chance} chance of summoning one barlgura.",
 						"A summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
 					]
 				}
@@ -5874,7 +5874,7 @@
 					"name": "Variant: Summon Demon (1/Day)",
 					"entries": [
 						"The demon chooses what to summon and attempts a magical summoning.",
-						"A chasme has a 30 percent chance of summoning one chasme.",
+						"A chasme has a {@chance 30|30 percent|30% summoning chance} chance of summoning one chasme.",
 						"A summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
 					]
 				}
@@ -8438,7 +8438,7 @@
 				{
 					"name": "Summon Demon (1/Day)",
 					"entries": [
-						"The drow magically summons a quasit, or attempts to summon a shadow demon with a 50 percent chance of success. The summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 10 minutes, until it or its summoner dies, or until its summoner dismisses it as an action."
+						"The drow magically summons a {@creature quasit}, or attempts to summon a {@creature shadow demon} with a {@chance 50|50 percent|50% summoning chance} chance of success. The summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 10 minutes, until it or its summoner dies, or until its summoner dismisses it as an action."
 					]
 				}
 			],
@@ -8576,7 +8576,7 @@
 				{
 					"name": "Summon Demon (1/Day)",
 					"entries": [
-						"The drow attempts to magically summon a yochlol with a 30 percent chance of success. If the attempt fails, the drow takes 5 (1d10) psychic damage. Otherwise, the summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 10 minutes, until it or its summoner dies, or until its summoner dismisses it as an action."
+						"The drow attempts to magically summon a {@creature yochlol} with a {@chance 30|30 percent|30% summoning chance} chance of success. If the attempt fails, the drow takes 5 (1d10) psychic damage. Otherwise, the summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 10 minutes, until it or its summoner dies, or until its summoner dismisses it as an action."
 					]
 				}
 			],
@@ -8996,7 +8996,7 @@
 				{
 					"name": "Variant: Summon Mephits (1/Day)",
 					"entries": [
-						"The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+						"The mephit has a {@chance 25|25 percent|25% summoning chance} chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
 					]
 				}
 			],
@@ -12848,7 +12848,7 @@
 					"name": "Variant: Summon Demon (1/Day)",
 					"entries": [
 						"The demon chooses what to summon and attempts a magical summoning.",
-						"A glabrezu has a 30 percent chance of summoning 1d3 vrocks, 1d2 hezrous, or one glabrezu.",
+						"A glabrezu has a {@chance 30|30 percent|30% summoning chance} chance of summoning 1d3 {@creature vrock}s, 1d2 {@creature hezrou}s, or one glabrezu.",
 						"A summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
 					]
 				}
@@ -14916,7 +14916,7 @@
 					"name": "Variant: Summon Demon (1/Day)",
 					"entries": [
 						"The demon chooses what to summon and attempts a magical summoning.",
-						"A hezrou has a 30 percent chance of summoning 2d6 dretches or one hezrou.",
+						"A hezrou has a {@chance 30|30 percent|30% summoning chance} chance of summoning 2d6 {@creature dretch}es or one hezrou.",
 						"A summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
 					]
 				}
@@ -15732,7 +15732,7 @@
 				{
 					"name": "Variant: Summon Mephits (1/Day)",
 					"entries": [
-						"The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+						"The mephit has a {@chance 30|30 percent|30% summoning chance} chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
 					]
 				}
 			],
@@ -17723,7 +17723,7 @@
 				{
 					"name": "Variant: Summon Mephits (1/Day)",
 					"entries": [
-						"The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+						"The mephit has a {@chance 25|25 percent|25% summoning chance} chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
 					]
 				}
 			],
@@ -18091,7 +18091,7 @@
 					"name": "Variant: Summon Demon (1/Day)",
 					"entries": [
 						"The demon chooses what to summon and attempts a magical summoning.",
-						"A marilith has a 50 percent chance of summoning 1d6 vrocks, 1d4 hezrous, 1d3 glabrezus, 1d2 nalfeshnees, or one marilith.",
+						"A marilith has a {@chance 50|50 percent|50% summoning chance} chance of summoning 1d6 {@creature vrock}s, 1d4 {@creature hezrou}s, 1d3 {@creature glabrezu}s, 1d2 {@creature nalfeshnee}s, or one marilith.",
 						"A summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
 					]
 				}
@@ -18379,7 +18379,7 @@
 					"name": "Variant: Summon Yugoloth (1/Day)",
 					"entries": [
 						"The yugoloth attempts a magical summoning.",
-						"A mezzoloth has a 30 percent chance of summoning one mezzoloth.",
+						"A mezzoloth has a {@chance 30|30 percent|30% summoning chance} chance of summoning one mezzoloth.",
 						"A summoned yugoloth appears in an unoccupied space within 60 feet of its summoner, does as it pleases, and can't summon other yugoloths. The summoned yugoloth remains for 1 minute, until it or its summoner dies, or until its summoner takes a bonus action to dismiss it."
 					]
 				}
@@ -18887,7 +18887,7 @@
 				{
 					"name": "Variant: Summon Mephits (1/Day)",
 					"entries": [
-						"The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+						"The mephit has a {@chance 25|25 percent|25% summoning chance} chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
 					]
 				}
 			],
@@ -19176,7 +19176,7 @@
 				{
 					"name": "Pacifying Spores (3/Day)",
 					"entries": [
-						"The myconid ejects spores at one creature it can see within 5 feet of it. The target must succeed on a DC 11 Constitution saving throw or be stunned for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+						"The myconid ejects spores at one creature it can see within 5 feet of it. The target must succeed on a DC 11 Constitution saving throw or be {@condition stunned} for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 					]
 				},
 				{
@@ -19186,7 +19186,45 @@
 					]
 				}
 			],
-			"page": 232
+			"variant": [
+				{
+					"type": "variant",
+					"name": "Zuggtmoy Enhancement (from OotA)",
+					"entries": [
+						{
+							"type": "entries",
+							"entries": [
+								"Myconids that embrace {@creature Zuggtmoy|OotA} can develop new, more destructive kinds of spores. Myconid adults can have two of the following spore effects.",
+								{
+									"name": "Caustic Spores (1/ Day)",
+									"entries": [
+										"The myconid releases spores in a 30-foot cone. Each creature inside the cone must succeed on a DC 11 Dexterity saving throw or take 1d6 acid damage at the start of each of the myconid's turns. A creature can repeat the saving throw at the end of its turn, ending the effect on itself on a success. The save DC is 8 + the myconid's Constitution modifier + the myconid's proficiency bonus."
+									]
+								},
+								{
+									"name": "Infestation Spores (1/Day)",
+									"entries": [
+										"The myconid releases spores that burst out in a cloud that fills a 10-foot-radius sphere centered on it, and the cloud lingers for 1 minute. Any flesh-and-blood creature in the cloud when it appears, or that enters it later, must make a DC 11 Constitution saving throw. The save DC is 8 + the myconid's Constitution modifier + the myconid's proficiency bonus. On a successful save, the creature can't be infected by these spores for 24 hours. On a failed save, the creature is infected with a disease called the spores of Zuggtmoy) and also gains a random form of indefinite madness (determined by rolling on the Madness of {@creature Zuggtmoy|OotA} table) that lasts until the creature is cured of the disease or dies. While infected in this way, the creature can't be reinfected, and it must repeat the saving throw at the end of every 24 hours, ending the infection on a success. On a failure, the infected creature's body is slowly taken over by fungal growth, and after three such failed saves, the creature dies and is reanimated as a spore servant if it's a humanoid or a Large or smaller beast."
+									]
+								},
+								{
+									"name": "Euphoria Spores (1/ Day)",
+									"entries": [
+										"The myconid releases a cloud of spores in a 20-foot-radius sphere centered on itself. Other creatures in that area must each succeed on a DC 11 Constitution saving throw or become poisoned for 1 minute. The save DC is 8 + the myconid's Constitution modifier + the myconid's proficiency bonus. A creature can repeat the saving throw at the end of each of its turns, ending the effect early on itself on a success. When the effect ends on it, the creature gains one level of {@condition exhaustion}."
+									]
+								}
+							]
+						}
+					]
+				}
+			],
+			"page": 232,
+			"additionalSources": [
+				{
+					"source": "OotA",
+					"page": 228
+				}
+			]
 		},
 		{
 			"name": "Myconid Sovereign",
@@ -19242,13 +19280,13 @@
 				{
 					"name": "Hallucination Spores",
 					"entries": [
-						"The myconid ejects spores at one creature it can see within 5 feet of it. The target must succeed on a DC 12 Constitution saving throw or be poisoned for 1 minute. The poisoned target is incapacitated while it hallucinates. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+						"The myconid ejects spores at one creature it can see within 5 feet of it. The target must succeed on a DC 12 Constitution saving throw or be {@condition poisoned} for 1 minute. The poisoned target is {@condition incapacitated} while it hallucinates. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 					]
 				},
 				{
 					"name": "Pacifying Spores",
 					"entries": [
-						"The myconid ejects spores at one creature it can see within 5 feet of it. The target must succeed on a DC 12 Constitution saving throw or be stunned for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+						"The myconid ejects spores at one creature it can see within 5 feet of it. The target must succeed on a DC 12 Constitution saving throw or be {@condition stunned} for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 					]
 				},
 				{
@@ -19258,7 +19296,45 @@
 					]
 				}
 			],
-			"page": 232
+			"variant": [
+				{
+					"type": "variant",
+					"name": "Zuggtmoy Enhancement (from OotA)",
+					"entries": [
+						{
+							"type": "entries",
+							"entries": [
+								"Myconids that embrace {@creature Zuggtmoy|OotA} can develop new, more destructive kinds of spores. Myconid sovereigns have all these spore effects.",
+								{
+									"name": "Caustic Spores (1/ Day)",
+									"entries": [
+										"The myconid releases spores in a 30-foot cone. Each creature inside the cone must succeed on a DC 12 Dexterity saving throw or take 1d6 acid damage at the start of each of the myconid's turns. A creature can repeat the saving throw at the end of its turn, ending the effect on itself on a success. The save DC is 8 + the myconid's Constitution modifier + the myconid's proficiency bonus."
+									]
+								},
+								{
+									"name": "Infestation Spores (1/Day)",
+									"entries": [
+										"The myconid releases spores that burst out in a cloud that fills a 10-foot-radius sphere centered on it, and the cloud lingers for 1 minute. Any flesh-and-blood creature in the cloud when it appears, or that enters it later, must make a DC 12 Constitution saving throw. The save DC is 8 + the myconid's Constitution modifier + the myconid's proficiency bonus. On a successful save, the creature can't be infected by these spores for 24 hours. On a failed save, the creature is infected with a disease called the spores of Zuggtmoy) and also gains a random form of indefinite madness (determined by rolling on the Madness of {@creature Zuggtmoy|OotA} table) that lasts until the creature is cured of the disease or dies. While infected in this way, the creature can't be reinfected, and it must repeat the saving throw at the end of every 24 hours, ending the infection on a success. On a failure, the infected creature's body is slowly taken over by fungal growth, and after three such failed saves, the creature dies and is reanimated as a spore servant if it's a humanoid or a Large or smaller beast."
+									]
+								},
+								{
+									"name": "Euphoria Spores (1/ Day)",
+									"entries": [
+										"The myconid releases a cloud of spores in a 20-foot-radius sphere centered on itself. Other creatures in that area must each succeed on a DC 12 Constitution saving throw or become poisoned for 1 minute. The save DC is 8 + the myconid's Constitution modifier + the myconid's proficiency bonus. A creature can repeat the saving throw at the end of each of its turns, ending the effect early on itself on a success. When the effect ends on it, the creature gains one level of {@condition exhaustion}."
+									]
+								}
+							]
+						}
+					]
+				}
+			],
+			"page": 232,
+			"additionalSources": [
+				{
+					"source": "OotA",
+					"page": 228
+				}
+			]
 		},
 		{
 			"name": "Myconid Sprout",
@@ -19379,7 +19455,7 @@
 					"name": "Variant: Summon Demon (1/Day)",
 					"entries": [
 						"The demon chooses what to summon and attempts a magical summoning.",
-						"A nalfeshnee has a 50 percent chance of summoning 1d4 vrocks, 1d3 hezrous, 1d2 glabrezus, or one nalfeshnee.",
+						"A nalfeshnee has a {@chance 50|50 percent|50% summoning chance} chance of summoning 1d4 {@creature vrock}s, 1d3 {@creature hezrou}s, 1d2 {@creature glabrezu}s, or one nalfeshnee.",
 						"A summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
 					]
 				}
@@ -19810,7 +19886,7 @@
 					"name": "Variant: Summon Yugoloth (1/Day)",
 					"entries": [
 						"The yugoloth chooses what to summon and attempts a magical summoning.",
-						"A nycaloth has a 50 percent chance of summoning 1d4 mezzoloths or one nycaloth.",
+						"A nycaloth has a {@chance 50|50 percent|50% summoning chance} chance of summoning 1d4 {@creature mezzoloth}s or one nycaloth.",
 						"A summoned yugoloth appears in an unoccupied space within 60 feet of its summoner, does as it pleases, and can't summon other yugoloths. The summoned yugoloth remains for 1 minute, until it or its summoner dies, or until its summoner takes a bonus action to dismiss it."
 					]
 				}
@@ -23794,7 +23870,7 @@
 				{
 					"name": "Variant: Summon Mephits (1/Day)",
 					"entries": [
-						"The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+						"The mephit has a {@chance 25|25 percent|25% summoning chance} chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
 					]
 				}
 			],
@@ -24426,7 +24502,7 @@
 				{
 					"name": "Variant: Summon Mephits (1/Day)",
 					"entries": [
-						"The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+						"The mephit has a {@chance 25|25 percent|25% summoning chance} chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
 					]
 				}
 			],
@@ -26213,7 +26289,7 @@
 					"name": "Variant: Summon Yugoloth (1/Day)",
 					"entries": [
 						"The yugoloth chooses what to summon and attempts a magical summoning.",
-						"An ultroloth has a 50 percent chance of summoning 1d6 mezzoloths, 1d4 nycaloths, or one ultroloth.",
+						"An ultroloth has a {@chance 50|50 percent|50% summoning chance} chance of summoning 1d6 {@creature mezzoloth}s, 1d4 {@creature nycaloth}s, or one ultroloth.",
 						"A summoned yugoloth appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other yugoloths. The summoned yugoloth remains for 1 minute, until it or its summoner dies, or until its summoner takes a bonus action to dismiss it."
 					]
 				}
@@ -27168,7 +27244,7 @@
 					"name": "Variant: Summon Demon (1/Day)",
 					"entries": [
 						"The demon chooses what to summon and attempts a magical summoning.",
-						"A vrock has a 30 percent chance of summoning 2d4 dretches or one vrock.",
+						"A vrock has a {@chance 30|30 percent|30% summoning chance} chance of summoning 2d4 {@creature dretch}es or one vrock.",
 						"A summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
 					]
 				}
@@ -28479,7 +28555,7 @@
 					"name": "Variant: Summon Demon (1/Day)",
 					"entries": [
 						"The demon chooses what to summon and attempts a magical summoning.",
-						"A yochlol has a 50 percent chance of summoning one yochlol.",
+						"A yochlol has a {@chance 50|50 percent|50% summoning chance} chance of summoning one yochlol.",
 						"A summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
 					]
 				}


### PR DESCRIPTION
Links to summoned creatures for aarakokra, drow mage, drow priestess, demons, etc.
using new format for success chance tag
`{@chance 50|50 percent|50% summoning chance}`
a tag still not supported (so some text will be cut)

Added variant features (from OotA) for Myconid Adult and Myconid Sovereign.