### PR TITLE
Update bestiary-lmop.json

### DIFF
--- a/data/bestiary/bestiary-lmop.json
+++ b/data/bestiary/bestiary-lmop.json
@@ -191,6 +191,26 @@
 			"passive": 14,
 			"languages": "Elvish, Undercommon",
 			"cr": "2",
+			"trait": [
+				{
+					"name": "Special Equipment",
+					"entries": [
+						"Nezznar has a {@item spider staff|lmop}."
+					]
+				},
+				{
+					"name": "Fey Ancestry",
+					"entries": [
+						"Nezznar has advantage on saving throws against being charmed, and magic can't put him to sleep."
+					]
+				},
+				{
+					"name": "Sunlight Sensitivity",
+					"entries": [
+						"Nezznar has disadvantage on attack rolls when he or his target is in sunlight."
+					]
+				}
+			],
 			"spellcasting": [
 				{
 					"name": "Innate Spellcasting",
@@ -236,26 +256,6 @@
 							]
 						}
 					}
-				}
-			],
-			"trait": [
-				{
-					"name": "Special Equipment",
-					"entries": [
-						"Nezznar has a spider staff."
-					]
-				},
-				{
-					"name": "Fey Ancestry",
-					"entries": [
-						"Nezznar has advantage on saving throws against being charmed, and magic can't put him to sleep."
-					]
-				},
-				{
-					"name": "Sunlight Sensitivity",
-					"entries": [
-						"Nezznar has disadvantage on attack rolls when he or his target is in sunlight."
-					]
 				}
 			],
 			"action": [


### PR DESCRIPTION
Nezznar: link to the spider staff.

Note: I don't understand why the spellcasting sections comes before the traits.
In my local copy I've swapped them but the innate and regular spellcasting
were displayed before anyway