### PR TITLE
Update bestiary-tftyp.json

### DIFF
--- a/data/bestiary/bestiary-tftyp.json
+++ b/data/bestiary/bestiary-tftyp.json
@@ -1791,7 +1791,7 @@
 				{
 					"name": "Special Equipment",
 					"entries": [
-						"Sharwyn has a spellbook that contains the spells listed in her Spellcasting trait, plus detect magic and silent image."
+						"Sharwyn has a {@item spellbook|phb} that contains the spells listed in her Spellcasting trait, plus {@spell detect magic} and {@spell silent image}."
 					]
 				},
 				{
@@ -1874,7 +1874,7 @@
 				{
 					"name": "Special Equipment",
 					"entries": [
-						"Sir Braford wields Shatterspike, a magic longsword that grants a +1 bonus to attack and damage rolls made with it (included in his attack). See the Shatterspike handout for the item's other properties."
+						"Sir Braford wields {@item Shatterspike|tftyp}, a magic longsword that grants a +1 bonus to attack and damage rolls made with it (included in his attack). See the Shatterspike handout for the item's other properties."
 					]
 				},
 				{


### PR DESCRIPTION
sharwyn and braford: link to "special equipment" items.

I've left "See the Shatterspike handout for the item's other properties." because, I don't know,
maybe if the creature is imported on roll20 it could be useful.