### PR TITLE
Update bestiary-toa.json

### DIFF
--- a/data/bestiary/bestiary-toa.json
+++ b/data/bestiary/bestiary-toa.json
@@ -430,7 +430,7 @@
 					"name": "Special Equipment",
 					"entries": [
 						"Artus wears the {@item Ring of Winter|toa}. He and the ring can't be targeted by divination magic or perceived through magical scrying sensors. While attuned to and wearing the ring, Artus ceases to age and is immune to cold damage and the effects of extreme cold.",
-				        	"Artus wields {@item Bookmark|toa} a +3 dagger with additional magical properties. As a bonus action, Artus can activate any one of the following properties while attuned to the dagger, provided he has the weapon drawn:",
+						"Artus wields {@item Bookmark|toa} a +3 dagger with additional magical properties. As a bonus action, Artus can activate any one of the following properties while attuned to the dagger, provided he has the weapon drawn:",
 						"• Cause a blue gem set into the dagger's pommel to shed bright light in a 20-foot radius and dim light for an additional 20 feet, or make the gem go dark.",
 						"• Turn the dagger into a compass that, while resting on your palm, points north.",
 						"• Cast {@spell dimension door} from the dagger. Once this property is used, it can't be used again until the next dawn.",

--- a/data/bestiary/bestiary-toa.json
+++ b/data/bestiary/bestiary-toa.json
@@ -429,8 +429,8 @@
 				{
 					"name": "Special Equipment",
 					"entries": [
-						"Artus wears the Ring of Winter. He and the ring can't be targeted by divination magic or perceived through magical scrying sensors. While attuned to and wearing the ring, Artus ceases to age and is immune to cold damage and the effects of extreme cold.",
-						"Artus wields Bookmark a +3 dagger with additional magical properties. As a bonus action, Artus can activate any one of the following properties while attuned to the dagger, provided he has the weapon drawn:",
+						"Artus wears the {@item Ring of Winter|toa}. He and the ring can't be targeted by divination magic or perceived through magical scrying sensors. While attuned to and wearing the ring, Artus ceases to age and is immune to cold damage and the effects of extreme cold.",
+				        	"Artus wields {@item Bookmark|toa} a +3 dagger with additional magical properties. As a bonus action, Artus can activate any one of the following properties while attuned to the dagger, provided he has the weapon drawn:",
 						"• Cause a blue gem set into the dagger's pommel to shed bright light in a 20-foot radius and dim light for an additional 20 feet, or make the gem go dark.",
 						"• Turn the dagger into a compass that, while resting on your palm, points north.",
 						"• Cast {@spell dimension door} from the dagger. Once this property is used, it can't be used again until the next dawn.",
@@ -1454,7 +1454,7 @@
 				{
 					"name": "Special Equipment",
 					"entries": [
-						"Ras Nsi wears bracers of defense, wields a flame tongue longsword, and carries a sending stone matched to the one carried by the guide Salida (see chapter 1)"
+						"Ras Nsi wears {@item bracers of defense}, wields a {@item flame tongue longsword}, and carries a {@item sending stones|dmg|sending stone} matched to the one carried by the guide Salida (see chapter 1)."
 					]
 				},
 				{


### PR DESCRIPTION
artus and ras nsi: link to "special equipment" items

Ras Nsi makes reference to the guide Salida, suggesting to see "Chapter 1" (of ToA).
Would be good to put a link to that adventure (maybe even to Salida herself,
since it seems there is an "anchor"), but I prefer not to take this initiative.