### PR TITLE
Bestiary, MM, vampire(s): link to summoned creatures

### DIFF
--- a/data/bestiary/bestiary-mm.json
+++ b/data/bestiary/bestiary-mm.json
@@ -26608,7 +26608,7 @@
 				{
 					"name": "Children of the Night (1/Day)",
 					"entries": [
-						"The vampire magically calls 2d4 swarms of bats or rats, provided that the sun isn't up. While outdoors, the vampire can call 3d6 wolves instead. The called creatures arrive in 1d4 rounds, acting as allies of the vampire and obeying its spoken commands. The beasts remain for 1 hour, until the vampire dies, or until the vampire dismisses them as a bonus action."
+						"The vampire magically calls 2d4 swarms of {@creature swarm of bats|mm|bats} or {@creature swarm of rats|mm|rats}, provided that the sun isn't up. While outdoors, the vampire can call 3d6 {@creature wolf|mm|wolves} instead. The called creatures arrive in 1d4 rounds, acting as allies of the vampire and obeying its spoken commands. The beasts remain for 1 hour, until the vampire dies, or until the vampire dismisses them as a bonus action."
 					]
 				}
 			],
@@ -26810,7 +26810,7 @@
 				{
 					"name": "Children of the Night (1/Day)",
 					"entries": [
-						"The vampire magically calls 2d4 swarms of bats or rats, provided that the sun isn't up. While outdoors, the vampire can call 3d6 wolves instead. The called creatures arrive in 1d4 rounds, acting as allies of the vampire and obeying its spoken commands. The beasts remain for 1 hour, until the vampire dies, or until the vampire dismisses them as a bonus action."
+						"The vampire magically calls 2d4 swarms of {@creature swarm of bats|mm|bats} or {@creature swarm of rats|mm|rats}, provided that the sun isn't up. While outdoors, the vampire can call 3d6 {@creature wolf|mm|wolves} instead. The called creatures arrive in 1d4 rounds, acting as allies of the vampire and obeying its spoken commands. The beasts remain for 1 hour, until the vampire dies, or until the vampire dismisses them as a bonus action."
 					]
 				}
 			],
@@ -26986,6 +26986,12 @@
 					]
 				},
 				{
+					"name": "Greatsword",
+					"entries": [
+						"Melee Weapon Attack: +9 to hit, reach 5 ft., one creature. Hit: 11 (2d6+4) slashing damage."
+					]
+				},
+				{
 					"name": "Bite (Bat or Vampire Form Only)",
 					"entries": [
 						"Melee Weapon Attack: +9 to hit, reach 5 ft., one willing creature, or a creature that is grappled by the vampire, incapacitated, or restrained. Hit: 7 (1d6+4) piercing damage plus 10 (3d6) necrotic damage. The target's hit point maximum is reduced by an amount equal to the necrotic damage taken, and the vampire regains hit points equal to that amount. The reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0. A humanoid slain in this way and then buried in the ground rises the following night as a vampire spawn under the vampire's control."
@@ -27001,13 +27007,7 @@
 				{
 					"name": "Children of the Night (1/Day)",
 					"entries": [
-						"The vampire magically calls 2d4 swarms of bats or rats, provided that the sun isn't up. While outdoors, the vampire can call 3d6 wolves instead. The called creatures arrive in 1d4 rounds, acting as allies of the vampire and obeying its spoken commands. The beasts remain for 1 hour, until the vampire dies, or until the vampire dismisses them as a bonus action."
-					]
-				},
-				{
-					"name": "Greatsword",
-					"entries": [
-						"Melee Weapon Attack: +9 to hit, reach 5 ft., one creature. Hit: 11 (2d6+4) slashing damage."
+						"The vampire magically calls 2d4 swarms of {@creature swarm of bats|mm|bats} or {@creature swarm of rats|mm|rats}, provided that the sun isn't up. While outdoors, the vampire can call 3d6 {@creature wolf|mm|wolves} instead. The called creatures arrive in 1d4 rounds, acting as allies of the vampire and obeying its spoken commands. The beasts remain for 1 hour, until the vampire dies, or until the vampire dismisses them as a bonus action."
 					]
 				}
 			],


### PR DESCRIPTION
Additionally to linking the creatures called by vampires, I've also moved the greatsword action
of the vampire warrior near the top since it is, arguably, one of the most used and need more
visibility (it was at the bottom).

Note: AFAIK, this was never addressed in errata or other places. Just my debatable interpretation.
The additional actions for the **Vampire Warrior**, multiattack and greatsword should also have
"(Vampire Form Only)". Otherwise a vampire in bat form could attack twice with the greatsword.

If it was me, I would keep only 1 multiattack entry:
- the default one since it talks about generic attacks so it could also cover the greatsword
- combining the text of the two if the intent is not to mix a greatsword attack with a bite.