### PR TITLE
Fluff bestiary MM, more grouping and better (to be checked/improved) formatting

### DIFF
--- a/data/bestiary/fluff-bestiary-mm.json
+++ b/data/bestiary/fluff-bestiary-mm.json
@@ -7,15 +7,33 @@
 				"type": "entries",
 				"entries": [
 					{
-						"type": "entries",
+						"type": "section",
 						"name": "Devils",
 						"entries": [
-							"Devils personify tyranny, with a totalitarian society dedicated to the domination of mortal life. The shadow of the Nine Hells of Baator extends far across the multiverse, and Asmodeus, the dark lord of Nessus, strives to subjugate the cosmos to satisfy his thirst for power. To do so, he must continually expand his infernal armies, sending his servants to the mortal realm to corrupt the souls from which new devils are spawned.",
-							"Lords of Tyranny. Devils live to conquer, enslave, and oppress. They take perverse delight in exercising authority over the weak, and any creature that defies the authority of a devil faces swift and cruel punishment. Every interaction is an opportunity for a devil to display its power, and all devils have a keen understanding of how to use and abuse their power.",
-							"Devils understand the failings that plague intelligent mortals, and they use that knowledge to lead mortals into temptation and darkness, turning creatures into slaves to their own corruption. Devils on the Material Plane use their influence to manipulate humanoid rulers, whispering evil thoughts, fomenting paranoia, and eventually driving them to tyrannical actions.",
-							"Obedience and Ambition. In accordance with their lawful alignment, devils obey even when they envy or dislike their superiors, knowing that their obedience will be rewarded. The hierarchy of the Nine Hells depends on this unswerving loyalty, without which that fiendish plane would become as anarchic as the Abyss.",
-							"At the same time, it is in the nature of devils to scheme, creating in some a desire to rule that eclipses their contentment to be ruled. This singular ambition is strongest among the archdevils whom Asmodeus appoints to rule the nine layers of the Nine Hells. These high-ranking fiends are the only devils to ever sample true power, which they crave like the sweetest ambrosia.",
-							"Dark Dealers and Soul Mongers. Devils are confined to the Lower Planes, but they can travel beyond those planes by way of portals or powerful summoning magic. They love to strike bargains with mortals seeking to gain some benefit or prize, but a mortal making such a bargain must be wary. Devils are crafty negotiators and positively ruthless at enforcing the terms of an agreement. Moreover, a contract with even the lowliest devil is enforced by Asmodeus's will. Any mortal creature that breaks such a contract instantly forfeits its soul, which is spirited away to the Nine Hells.",
+							"Devils personify tyranny, with a totalitarian society dedicated to the domination of mortal life. The shadow of the Nine Hells of Baator extends far across the multiverse, and Asmodeus, the dark lord of Nessus, strives to subjugate the cosmos to satisfy his thirst for power. To do so, he must continually expand his infernal armies, sending his servants to the mortal realm to corrupt the souls from which new devils are spawned."
+						]
+					},
+					{
+						"type": "entries",
+						"name": "Lords of Tyranny",
+						"entries": [
+							"Devils live to conquer, enslave, and oppress. They take perverse delight in exercising authority over the weak, and any creature that defies the authority of a devil faces swift and cruel punishment. Every interaction is an opportunity for a devil to display its power, and all devils have a keen understanding of how to use and abuse their power.",
+							"Devils understand the failings that plague intelligent mortals, and they use that knowledge to lead mortals into temptation and darkness, turning creatures into slaves to their own corruption. Devils on the Material Plane use their influence to manipulate humanoid rulers, whispering evil thoughts, fomenting paranoia, and eventually driving them to tyrannical actions."
+						]
+					},
+					{
+						"type": "entries",
+						"name": "Obedience and Ambition",
+						"entries": [
+							"In accordance with their lawful alignment, devils obey even when they envy or dislike their superiors, knowing that their obedience will be rewarded. The hierarchy of the Nine Hells depends on this unswerving loyalty, without which that fiendish plane would become as anarchic as the Abyss.",
+							"At the same time, it is in the nature of devils to scheme, creating in some a desire to rule that eclipses their contentment to be ruled. This singular ambition is strongest among the archdevils whom Asmodeus appoints to rule the nine layers of the Nine Hells. These high-ranking fiends are the only devils to ever sample true power, which they crave like the sweetest ambrosia."
+						]
+					},
+					{
+						"type": "entries",
+						"name": "Dark Dealers and Soul Mongers",
+						"entries": [
+							"Devils are confined to the Lower Planes, but they can travel beyond those planes by way of portals or powerful summoning magic. They love to strike bargains with mortals seeking to gain some benefit or prize, but a mortal making such a bargain must be wary. Devils are crafty negotiators and positively ruthless at enforcing the terms of an agreement. Moreover, a contract with even the lowliest devil is enforced by Asmodeus's will. Any mortal creature that breaks such a contract instantly forfeits its soul, which is spirited away to the Nine Hells.",
 							"To own a creature's soul is to have absolute control over that creature, and most devils accept no other currency in exchange for the fiendish power and boons they can provide. A soul is usually forfeited when a mortal dies naturally, for devils are immortal and can wait years for a contract to play out. If a contract allows a devil to claim a mortal's soul before death, it can instantly return to the Nine Hells with the soul in its possession. Only divine intervention can release a soul after a devil has claimed it."
 						]
 					},
@@ -23,110 +41,128 @@
 						"type": "entries",
 						"name": "The Infernal Hierarchy",
 						"entries": [
-							"The Nine Hells has a rigid hierarchy that defines every aspect of its society. Asmodeus is the supreme ruler of all devils, and the only creature in the Nine Hells with the powers of a lesser god. Worshiped as such in the Material Plane, Asmodeus inspires the evil humanoid cults that take his name. In the Nine Hells, he commands scores of pit fiend generals, which in turn command legions of subordinates.",
-							"A supreme tyrant, a brilliant deceiver, and a master of subtlety, Asmodeus protects his throne by keeping his friends close and his enemies closer. He delegates most matters of rulership to the pit fiends and lesser archdevils that make up the infernal bureaucracy of the Nine Hells, even as he knows that those powerful devils conspire to usurp the Throne of Baator from which he rules. Asmodeus appoints archdevils, and he can strip any member of the infernal hierarchy of rank and status as he likes.",
-							"If it dies outside the Nine Hells, a devil disappears in a cloud of sulfurous smoke or dissolves into a pool of ichor, instantly returning to its home layer, where it reforms at full strength. Devils that die in the Nine Hells are destroyed forever-a fate that even Asmodeus fears.",
-							"Archdevils. The archdevils include all the current and deposed rulers of the Nine Hells (see the Layers and Lords of the Nine Hells table), as well as the dukes and duchesses that make up their courts, attend them as advisers, and hope to supplant them. Every archdevil is a unique being with an appearance that reflects its",
-							"particular evil nature.",
-							"Greater Devils. The greater devils include the pit fiends, erinyes, horned devils, and ice devils that command lesser devils and attend the archdevils.",
-							"Lesser Devils. The lesser devils include numerous strains of fiends, including imps, chain devils, spined devils, bearded devils, barbed devils, and bone devils.",
-							"Lemures. The lowest form of devil, lemures are the twisted and tormented souls of evil and corrupted mortals. A lemure killed in the Nine Hells is only permanently destroyed if it is killed with a blessed weapon or if its shapeless corpse is splashed with holy water before it can return to life.",
-							"Promotion and Demotion. When the soul of an evil mortal sinks into the Nine Hells, it takes on the physical form of a wretched lemure. Archdevils and greater devils have the power to promote lemures to lesser devils. Archdevils can promote lesser devils to greater devils, and Asmodeus alone can promote a greater devil to archdevil status. This diabolic promotion invokes a brief, painful transformation, with the devil's memories passing intact from one form to the next.",
-							"Low-level promotions are typically based on need, such as when a pit fiend transforms lemures into imps to gain invisible spies under its command. High-level promotions are almost always based on merit, such as when a bone devil that distinguishes itself in battle is transformed into a horned devil by the archdevil it serves. A devil is seldom promoted more than one step at a time in the hierarchy of infernal forms.",
 							{
-								"type": "table",
-								"caption": "Infernal Hierarchy",
-								"colLabels": [
-									"Rank",
-									"Devil(s)"
-								],
-								"colStyles": [
-									"col-xs-4",
-									"col-xs-8"
-								],
-								"rows": [
-									[
-										"1.",
-										"lemure"
+								"type": "entries",
+								"entries": [
+									"The Nine Hells has a rigid hierarchy that defines every aspect of its society. Asmodeus is the supreme ruler of all devils, and the only creature in the Nine Hells with the powers of a lesser god. Worshiped as such in the Material Plane, Asmodeus inspires the evil humanoid cults that take his name. In the Nine Hells, he commands scores of pit fiend generals, which in turn command legions of subordinates.",
+									"A supreme tyrant, a brilliant deceiver, and a master of subtlety, Asmodeus protects his throne by keeping his friends close and his enemies closer. He delegates most matters of rulership to the pit fiends and lesser archdevils that make up the infernal bureaucracy of the Nine Hells, even as he knows that those powerful devils conspire to usurp the Throne of Baator from which he rules. Asmodeus appoints archdevils, and he can strip any member of the infernal hierarchy of rank and status as he likes.",
+									"If it dies outside the Nine Hells, a devil disappears in a cloud of sulfurous smoke or dissolves into a pool of ichor, instantly returning to its home layer, where it reforms at full strength. Devils that die in the Nine Hells are destroyed forever-a fate that even Asmodeus fears.",
+									{
+										"type": "entries",
+										"name": "Archdevils",
+										"entries": [
+											"The archdevils include all the current and deposed rulers of the Nine Hells (see the Layers and Lords of the Nine Hells table), as well as the dukes and duchesses that make up their courts, attend them as advisers, and hope to supplant them. Every archdevil is a unique being with an appearance that reflects its particular evil nature."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Greater Devils",
+										"entries": [
+											"The greater devils include the pit fiends, erinyes, horned devils, and ice devils that command lesser devils and attend the archdevils."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Lesser Devils",
+										"entries": [
+											"The lesser devils include numerous strains of fiends, including imps, chain devils, spined devils, bearded devils, barbed devils, and bone devils."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Lemures",
+										"entries": [
+											"The lowest form of devil, lemures are the twisted and tormented souls of evil and corrupted mortals. A lemure killed in the Nine Hells is only permanently destroyed if it is killed with a blessed weapon or if its shapeless corpse is splashed with holy water before it can return to life."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Promotion and Demotion",
+										"entries": [
+											"When the soul of an evil mortal sinks into the Nine Hells, it takes on the physical form of a wretched lemure. Archdevils and greater devils have the power to promote lemures to lesser devils. Archdevils can promote lesser devils to greater devils, and Asmodeus alone can promote a greater devil to archdevil status. This diabolic promotion invokes a brief, painful transformation, with the devil's memories passing intact from one form to the next.",
+											"Low-level promotions are typically based on need, such as when a pit fiend transforms lemures into imps to gain invisible spies under its command. High-level promotions are almost always based on merit, such as when a bone devil that distinguishes itself in battle is transformed into a horned devil by the archdevil it serves. A devil is seldom promoted more than one step at a time in the hierarchy of infernal forms.",
+											"Demotion is the customary punishment for failure or disobedience among the devils. Archdevils or greater devils can demote a lesser devil to a lemure, which loses all memory of its prior existence. An archdevil can demote a greater devil to lesser devil status, but the demoted devil retains its memories-and might seek vengeance if the severity of the demotion is excessive.",
+											"No devil can promote or demote another devil that has not sworn fealty to it, preventing rival archdevils from demoting each other's most powerful servants. Since all devils swear fealty to Asmodeus, he can freely demote any other devil, transforming it into whatever infernal form he desires.",
+											{
+									"type": "table",
+									"caption": "Infernal Hierarchy",
+									"colLabels": [
+										"Rank",
+										"Devil(s)"
 									],
-									[
-										"2. (Lesser devils)",
-										"imp"
+									"colStyles": [
+										"col-xs-4",
+										"col-xs-8"
 									],
-									[
-										"3.",
-										"spined devil"
-									],
-									[
-										"4.",
-										"bearded devil"
-									],
-									[
-										"5.",
-										"barbed devil"
-									],
-									[
-										"6.",
-										"chain devil"
-									],
-									[
-										"7.",
-										"bone devil"
-									],
-									[
-										"8. (Greater devils)",
-										"horned devil"
-									],
-									[
-										"9.",
-										"erinyes"
-									],
-									[
-										"10.",
-										"ice devil"
-									],
-									[
-										"11.",
-										"pit fiend"
-									],
-									[
-										"12. (Archdevils)",
-										"duke or duchess"
-									],
-									[
-										"13.",
-										"archduke or archduchess"
+									"rows": [
+										[
+											"1.",
+											"lemure"
+										],
+										[
+											"2. (Lesser devils)",
+											"imp"
+										],
+										[
+											"3.",
+											"spined devil"
+										],
+										[
+											"4.",
+											"bearded devil"
+										],
+										[
+											"5.",
+											"barbed devil"
+										],
+										[
+											"6.",
+											"chain devil"
+										],
+										[
+											"7.",
+											"bone devil"
+										],
+										[
+											"8. (Greater devils)",
+											"horned devil"
+										],
+										[
+											"9.",
+											"erinyes"
+										],
+										[
+											"10.",
+											"ice devil"
+										],
+										[
+											"11.",
+											"pit fiend"
+										],
+										[
+											"12. (Archdevils)",
+											"duke or duchess"
+										],
+										[
+											"13.",
+											"archduke or archduchess"
+										]
 									]
+								}
+										]
+									}
 								]
-							},
-							"Demotion is the customary punishment for failure or disobedience among the devils. Archdevils or greater devils can demote a lesser devil to a lemure, which loses all memory of its prior existence. An archdevil can demote a greater devil to lesser devil status, but the demoted devil retains its memories-and might seek vengeance if the severity of the demotion is excessive.",
-							"No devil can promote or demote another devil that has not sworn fealty to it, preventing rival archdevils from demoting each other's most powerful servants. Since all devils swear fealty to Asmodeus, he can freely demote any other devil, transforming it into whatever infernal form he desires.",
-							"Devil True Names and Talismans",
-							"Though devils all have common names, every devil above a lemure in station also has a true name that it keeps secret. A devil can be forced to disclose its true name if charmed, and ancient scrolls and tomes are said to exist that list the true names of certain devils.",
-							"A mortal who learns a devil's true name can use powerful summoning magic to call the devil from the Nine Hells and bind it into service. Binding can also be accomplished with the help of a devil talisman. Each of these ancient relics is inscribed with the true name of a devil it controls, and was bathed in the blood of a worthy sacrifice-typically someone the creator loved-when crafted.",
-							"However it is summoned, a devil brought to the Material Plane typically resents being pressed into service. However, the devil seizes every opportunity to corrupt its summoner so that the summoner's soul ends up in the Nine Hells. Only imps are truly content to be summoned, and they easily commit to serving a summoner as a familiar, but they still do their utmost to corrupt those who summon them.",
-							"Variant: Devil Summoning",
-							"Some devils can have an action option that allows them to summon other devils.",
-							"Summon Devil (1/Day). The devil chooses what to summon and attempts a magical summoning.",
-							{
-								"type": "list",
-								"items": [
-									"A barbed devil has a 30 percent chance of summoning one barbed devil.",
-									"A bearded devil has a 30 percent chance of summoning one bearded devil.",
-									"A bone devil has a 40 percent chance of summoning 2d6 spined devils or one bone devil.",
-									"An erinyes has a 50 percent chance of summoning 3d6 spined devils, 1d6 bearded devils, or one erinyes.",
-									"A horned devil has a 30 percent chance of summoning one horned devil.",
-									"An ice devil has a 60 percent chance of summoning one ice devil.",
-									"A pit fiend summons 2d4 bearded devils, 1d4 barbed devils, or one erinyes with no chance of failure."
-								]
-							},
-							"A summoned devil appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other devils. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action.",
-							"The Nine Hells",
+							}
+						]
+					},
+					{
+						"type": "entries",
+						"name": "The Nine Hells",
+						"entries": [
 							"The Nine Hells are a single plane comprising nine separate layers (see the Layers and Lords of the Nine Hells table). The first eight layers are each ruled by archdevils that answer to the greatest archdevil of all: Asmodeus, the Archduke of Nessus, the ninth layer. To reach the deepest layer of the Nine Hells, one must descend through all eight of the layers above it, in order. The most expeditious means of doing so is the River Styx, which plunges ever deeper as it flows from one layer to the next. Only the most courageous adventurers can withstand the torment and horror of that journey.",
-							"Layers and Lords of the Nine Hells Layer",
 							{
 								"type": "table",
-								"caption": "",
+								"caption": "Layers and Lords of the Nine Hells Layer",
 								"colLabels": [
 									"Layer",
 									"Layer Name",
@@ -207,6 +243,36 @@
 									]
 								]
 							}
+						]
+					},
+					{
+						"type": "inset",
+						"name": "Devil True Names and Talismans",
+						"entries": [
+							"Though devils all have common names, every devil above a lemure in station also has a true name that it keeps secret. A devil can be forced to disclose its true name if charmed, and ancient scrolls and tomes are said to exist that list the true names of certain devils.",
+							"A mortal who learns a devil's true name can use powerful summoning magic to call the devil from the Nine Hells and bind it into service. Binding can also be accomplished with the help of a devil talisman. Each of these ancient relics is inscribed with the true name of a devil it controls, and was bathed in the blood of a worthy sacrifice-typically someone the creator loved-when crafted.",
+							"However it is summoned, a devil brought to the Material Plane typically resents being pressed into service. However, the devil seizes every opportunity to corrupt its summoner so that the summoner's soul ends up in the Nine Hells. Only imps are truly content to be summoned, and they easily commit to serving a summoner as a familiar, but they still do their utmost to corrupt those who summon them."
+						]
+					},
+					{
+						"type": "inset",
+						"name": "Variant: Devil Summoning",
+						"entries": [
+							"Some devils can have an action option that allows them to summon other devils.",
+							"Summon Devil (1/Day). The devil chooses what to summon and attempts a magical summoning.",
+							{
+								"type": "list",
+								"items": [
+									"A barbed devil has a 30 percent chance of summoning one barbed devil.",
+									"A bearded devil has a 30 percent chance of summoning one bearded devil.",
+									"A bone devil has a 40 percent chance of summoning 2d6 spined devils or one bone devil.",
+									"An erinyes has a 50 percent chance of summoning 3d6 spined devils, 1d6 bearded devils, or one erinyes.",
+									"A horned devil has a 30 percent chance of summoning one horned devil.",
+									"An ice devil has a 60 percent chance of summoning one ice devil.",
+									"A pit fiend summons 2d4 bearded devils, 1d4 barbed devils, or one erinyes with no chance of failure."
+								]
+							},
+							"A summoned devil appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other devils. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
 						]
 					}
 				]
@@ -750,6 +816,120 @@
 			}
 		},
 		{
+			"name": "Giant",
+			"source": "MM",
+			"entries": {
+				"entries": [
+					{
+						"type": "section",
+						"name": "Giants",
+						"entries": [
+							"Ancient empires once cast long shadows over a world that quaked beneath the giants' feet. In those lost days, these towering figures were dragon slayers, dreamers, crafters, and kings, but their kind fell from glory long ago. However, even divided among secluded clans scattered throughout the world, the giants maintain the customs and traditions of old.",
+							"Old as Legend. In remote regions of the world, the last remaining plinths, monoliths, and statues of the great giant empires bow their heads in desolate obscurity. Where once those empires sprawled across all lands, now the giants dwell in isolated tribes and clans.",
+							"Giants are almost as old as dragons, which were still young when the giants' heavy feet first shook the foundations of the world. As they spread across new lands, giants and dragons fought bitter generational wars that nearly brought both sides low. No living giant remembers what started the conflict, but myths and tales of their race's glorious dawn are still sung in their steadings and holdfasts, vilifying the primeval wyrms. Giants and dragons continue to harbor grudges against one another, and it is seldom that they will meet or occupy the same area without a fight."
+						]
+					},
+					{
+						"type": "entries",
+						"name": "The Ordning",
+						"entries": [
+							"Each of the main giant races-the cloud, fire, frost, hill, stone, and storm giants-are related by common elements of history, religion, and culture. They view one another as kindred, keeping any inherent animosity over territory and ambition to a minimum.",
+							"Giants belong to a caste structure called the ordning. Based on social class and highly organized, the ordning assigns a social rank to each giant. By understanding its place in the ordning, a giant knows which other giants are inferior or superior to it, since no two giants are equal. Each of the giant races analyzes a different combination of skills or qualities to determine the ordning. Giants make excelling in these qualities the purpose of their lives.",
+							"At the highest level of the ordning, the races of the giants are also ranked according to status. Storm giants are the highest in the ordning, followed by cloud giants, fire giants, frost giants, stone giants, hill giants, and finally giant kin such as fomorians, ettins, and ogres.",
+							"Regardless of a giant's rank among its own race, the chief of a hill giant tribe is inferior to the most common of stone giants. The lowest ranked giant of any type is superior to the highest ranked giant of an inferior type. It isn't considered evil to disrespect or even betray a giant of another type, merely rude."
+						]
+					},
+					{
+						"type": "entries",
+						"name": "Giant Gods",
+						"entries": [
+							"When the giants' ancient empires fell, Annam, father of all giants, forsook his children and the world. He swore never to look upon either again until the giants had returned to their glory and reclaimed their birthright as rulers of the world. As a result, giants pray not to Annam but to his divine children, along with a host of hero-deities and godly villains that make up the giants' pantheon.",
+							"Chief among these gods are the children of Annam, whose sons represent each type of giant: Stronmaus for storm giants, Memnor for cloud giants, Skoraeus Stonebones for stone giants, Thrym for frost giants, Surtur for fire giants, and Grolantor for hill giants. Not all giants automatically revere their kind's primary deity, however. Many good cloud giants refuse to worship the deceitful Memnor, and a storm giant dwelling in the icy mountains of the north might pay more homage to Thrym than Stronmaus. Other giants feel a stronger connection to Annam's daughters, who include Hiatea, the huntress and home warden; Iallanis, goddess of love and peace; and Diancastra, an impetuous and arrogant trickster.",
+							"Some giants abandon their own gods and fall prey to demon cults, paying homage to Baphomet or Kostchtchie. To worship them or any other non-giant deity is a great sin against the ordning, and almost certain to make a giant an outcast."
+						]
+					}
+				]
+			}
+		},
+		{
+			"name": "Elemental",
+			"source": "MM",
+			"entries": {
+				"type": "entries",
+				"name": "Elementals",
+				"entries": [
+					{
+						"type": "section",
+						"name": "Elementals",
+						"entries": [
+							"Elementals are incarnations of the elements that make up the universe: air, earth, fire, and water. Though little more than animated energy on their own planes of existence, they can be called on by spellcasters and powerful beings to take shape and perform tasks."
+						]
+					},
+					{
+						"type": "entries",
+						"name": "Living Elements",
+						"entries": [
+							"On its home plane, an elemental is a bodiless life force. Its dim consciousness manifests as a physical shape only when focused by the power of magic. A wild spirit of elemental force has no desire except to course through the element of its native plane. Like beasts of the Material Plane, these elemental spirits have no society or culture, and little sense of being."
+						]
+					},
+					{
+						"type": "entries",
+						"name": "Conjured by Magic",
+						"entries": [
+							"Certain spells and magic items can conjure an elemental, summoning it from the Inner Planes to the Material Plane. Elementals instinctively resent being pulled from their native planes and bound into service. A creature that summons an elemental must assert force of will to control it."
+						]
+					},
+					{
+						"type": "entries",
+						"name": "Bound and Shaped",
+						"entries": [
+							"Powerful magic can bind an elemental spirit into a material template that defines a specific use and function. Invisible stalkers are air elementals bound to a specific form, in the same way that water elementals can be shaped into water weirds."
+						]
+					},
+					{
+						"type": "entries",
+						"name": "Elemental Nature",
+						"entries": [
+							"An elemental doesn't require air, food, drink, or sleep."
+						]
+					}
+				]
+			}
+		},
+		{
+			"name": "Mephit",
+			"source": "MM",
+			"entries": {
+				"type": "entries",
+				"name": "Mephits",
+				"entries": [
+					{
+						"type": "section",
+						"name": "Mephits",
+						"entries": [
+							"Mephits are capricious, imp-like creatures native to the elemental planes. They come in six varieties, each one representing the mixture of two elements.",
+							"Ageless tricksters, mephits gather in large numbers on the Elemental Planes and in the Elemental Chaos. They also find their way to the Material Plane, where they prefer to dwell in places where their base elements are abundant. For example, a magma mephit is composed of earth and fire, and it favors volcanic lairs, while an ice mephit, which is composed of air and water, favors frigid locales."
+						]
+					},
+					{
+						"type": "entries",
+						"name": "Elemental Nature",
+						"entries": [
+							"A mephit doesn't require food, drink, or sleep."
+						]
+					},
+					{
+						"type": "inset",
+						"name": "Variant: Mephit Summoning",
+						"entries": [
+							"Some mephits can have an action option that allows them to summon other mephits.",
+							"Summon Mephits (1/Day). The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+						]
+					}
+				]
+			}
+		},
+		{
 			"name": "Aarakocra",
 			"source": "MM",
 			"images": [
@@ -967,20 +1147,12 @@
 				"type": "entries",
 				"entries": [
 					"An air elemental is a funneling cloud of whirling air with a vague semblance of a face. Although it likes to race across the ground, picking up dust and debris as it goes, it can also fly and attack from above.",
-					"An air elemental can turn itself into a screaming cyclone, creating a whirlwind that batters creatures even as it flings them away.",
-					{
-						"type": "entries",
-						"name": "Elementals",
-						"entries": [
-							"Elementals are incarnations of the elements that make up the universe: air, earth, fire, and water. Though little more than animated energy on their own planes of existence, they can be called on by spellcasters and powerful beings to take shape and perform tasks.",
-							"Living Elements. On its home plane, an elemental is a bodiless life force. Its dim consciousness manifests as a physical shape only when focused by the power of magic. A wild spirit of elemental force has no desire except to course through the element of its native plane. Like beasts of the Material Plane, these elemental spirits have no society or culture, and little sense of being.",
-							"Conjured by Magic. Certain spells and magic items can conjure an elemental, summoning it from the Inner Planes to the Material Plane. Elementals instinctively resent being pulled from their native planes and bound into service. A creature that summons an elemental must assert force of will to control it.",
-							"Bound and Shaped. Powerful magic can bind an elemental spirit into a material template that defines a specific use and function. Invisible stalkers are air elementals bound to a specific form, in the same way that water elementals can be shaped into water weirds.",
-							"The strength of the magic and materials that bind an elemental determines how well the elemental functions in a bound form. Golems are elemental spirits bound to physical forms, but weaker materials such as flesh and clay can't bind elemental power sufficiently. Durable materials such as stone and iron require stronger magic, which consequently binds an elemental more securely.",
-							"Elemental Nature. An elemental doesn't require air, food, drink, or sleep."
-						]
-					}
+					"An air elemental can turn itself into a screaming cyclone, creating a whirlwind that batters creatures even as it flings them away."
 				]
+			},
+			"_appendCopy": {
+				"name": "Elemental",
+				"source": "MM"
 			}
 		},
 		{
@@ -2101,45 +2273,45 @@
 				"type": "entries",
 				"entries": [
 					"Cloud giants live extravagant lives high above the world, showing little concern for the plights of other races except as amusement. They are muscular with light skin and have hair of silver or blue.",
-					"High and Mighty. Cloud giants are spread to the winds, encompassing vast areas of the world. In times of need, scattered cloud giant families band together as a unified clan. However, they can seldom do so quickly.",
-					"Attuned to the magic of their airy domains, cloud giants are able to turn into mist and create clouds of billowing fog. They dwell in castles on high mountain peaks, or on the solid clouds that once held their fiefs.",
-					"Still gracing the skies on occasion, these magic clouds are a lasting remnant of the giants' lost empires. Better spellcasters than most other giants, some cloud giants can control weather, bring storms, and steer the wind almost as well as their cousins, the storm giants.",
-					"Affluent Princes. Although cloud giants are lower in the ordning than storm giants, the reclusive storm giants rarely engage with the rest of giantkind. As a result, many cloud giants see themselves as having the highest status and power among the giant races.",
-					"They order lesser giants to seek out wealth and art on their behalf, employing fire giants as smiths and crafters, and using frost giants as reavers, raiders, and plunderers. Dimwitted hill giants serve them as brutes and combat fodder-sometimes fighting for the cloud giants' amusement. A cloud giant might order hill or frost giants to steal from nearby humanoid lands, which it considers to be a fair tax for its continued beneficence. On their mountain summits and solid clouds, cloud giants keep extraordinary gardens. Grapes as big as apples grow there, along with apples the size of pumpkins, and pumpkins the size of wagons. From the errant seeds of these gardens, tales of cottage sized produce and magic beans are spread in the mortal realm.",
-					"As humanoid nobles keep an aerie for hunting hawks, so do cloud giants keep griffons, perytons, and wyverns as their own flying beasts of prey. Such creatures also patrol the cloud giants' gardens by night, along with trained predators such as owlbears and lions.",
-					"Children of the Trickster. The patron god and father of the cloud giants is Memnor the Trickster, the cleverest and slyest of the giant deities. Cloud giants align themselves according to the aspects and exploits of Memnor that they most admire, with evil cloud giants emulating his deceitfulness and self-interest and good cloud giants emulating his intellect and silver-tongued speech. Family members usually align in the same direction.",
-					"Wealth and Power. A cloud giant earns its place in the ordning by the treasure it accumulates, the wealth it wears, and the gifts it bestows on other cloud giants.",
-					"However, value is only one part of the assessment. The extravagances a cloud giant wears or places about its home must also be beautiful or wondrous. Sacks of gold or gems are worth less to a cloud giant than the jewelry that might be crafted from those materials, creating treasures that bring esteem to a cloud giant's household.",
-					"Rather than steal from one another or fight over treasures, cloud giants are inveterate gamblers with a hunger for high risks and high rewards. They frequently bet on the outcome of events nominally outside their control, such as the lives of lesser creatures. Ordning ranks and kings' ransoms can be won and lost in bets over the military triumphs of humanoid nations. Fixing wagers by interfering in the conflict causes the loss of the bet, but such deceit is considered to be cheating only if it is discovered. Otherwise, it is cleverness honoring Memnor.",
 					{
 						"type": "entries",
-						"name": "Giants",
+						"name": "High and Mighty",
 						"entries": [
-							"Ancient empires once cast long shadows over a world that quaked beneath the giants' feet. In those lost days, these towering figures were dragon slayers, dreamers, crafters, and kings, but their kind fell from glory long ago. However, even divided among secluded clans scattered throughout the world, the giants maintain the customs and traditions of old.",
-							"Old as Legend. In remote regions of the world, the last remaining plinths, monoliths, and statues of the great giant empires bow their heads in desolate obscurity. Where once those empires sprawled across all lands, now the giants dwell in isolated tribes and clans.",
-							"Giants are almost as old as dragons, which were still young when the giants' heavy feet first shook the foundations of the world. As they spread across new lands, giants and dragons fought bitter generational wars that nearly brought both sides low. No living giant remembers what started the conflict, but myths and tales of their race's glorious dawn are still sung in their steadings and holdfasts, vilifying the primeval wyrms. Giants and dragons continue to harbor grudges against one another, and it is seldom that they will meet or occupy the same area without a fight."
+							"Cloud giants are spread to the winds, encompassing vast areas of the world. In times of need, scattered cloud giant families band together as a unified clan. However, they can seldom do so quickly.",
+							"Attuned to the magic of their airy domains, cloud giants are able to turn into mist and create clouds of billowing fog. They dwell in castles on high mountain peaks, or on the solid clouds that once held their fiefs.",
+							"Still gracing the skies on occasion, these magic clouds are a lasting remnant of the giants' lost empires. Better spellcasters than most other giants, some cloud giants can control weather, bring storms, and steer the wind almost as well as their cousins, the storm giants."
 						]
 					},
 					{
 						"type": "entries",
-						"name": "The Ordning",
+						"name": "Affluent Princes",
 						"entries": [
-							"Each of the main giant races-the cloud, fire, frost, hill, stone, and storm giants-are related by common elements of history, religion, and culture. They view one another as kindred, keeping any inherent animosity over territory and ambition to a minimum.",
-							"Giants belong to a caste structure called the ordning. Based on social class and highly organized, the ordning assigns a social rank to each giant. By understanding its place in the ordning, a giant knows which other giants are inferior or superior to it, since no two giants are equal. Each of the giant races analyzes a different combination of skills or qualities to determine the ordning. Giants make excelling in these qualities the purpose of their lives.",
-							"At the highest level of the ordning, the races of the giants are also ranked according to status. Storm giants are the highest in the ordning, followed by cloud giants, fire giants, frost giants, stone giants, hill giants, and finally giant kin such as fomorians, ettins, and ogres.",
-							"Regardless of a giant's rank among its own race, the chief of a hill giant tribe is inferior to the most common of stone giants. The lowest ranked giant of any type is superior to the highest ranked giant of an inferior type. It isn't considered evil to disrespect or even betray a giant of another type, merely rude."
+							"Although cloud giants are lower in the ordning than storm giants, the reclusive storm giants rarely engage with the rest of giantkind. As a result, many cloud giants see themselves as having the highest status and power among the giant races.",
+							"They order lesser giants to seek out wealth and art on their behalf, employing fire giants as smiths and crafters, and using frost giants as reavers, raiders, and plunderers. Dimwitted hill giants serve them as brutes and combat fodder-sometimes fighting for the cloud giants' amusement. A cloud giant might order hill or frost giants to steal from nearby humanoid lands, which it considers to be a fair tax for its continued beneficence. On their mountain summits and solid clouds, cloud giants keep extraordinary gardens. Grapes as big as apples grow there, along with apples the size of pumpkins, and pumpkins the size of wagons. From the errant seeds of these gardens, tales of cottage sized produce and magic beans are spread in the mortal realm.",
+							"As humanoid nobles keep an aerie for hunting hawks, so do cloud giants keep griffons, perytons, and wyverns as their own flying beasts of prey. Such creatures also patrol the cloud giants' gardens by night, along with trained predators such as owlbears and lions."
 						]
 					},
 					{
 						"type": "entries",
-						"name": "Giant Gods",
+						"name": "Children of the Trickster",
 						"entries": [
-							"When the giants' ancient empires fell, Annam, father of all giants, forsook his children and the world. He swore never to look upon either again until the giants had returned to their glory and reclaimed their birthright as rulers of the world. As a result, giants pray not to Annam but to his divine children, along with a host of hero-deities and godly villains that make up the giants' pantheon.",
-							"Chief among these gods are the children of Annam, whose sons represent each type of giant: Stronmaus for storm giants, Memnor for cloud giants, Skoraeus Stonebones for stone giants, Thrym for frost giants, Surtur for fire giants, and Grolantor for hill giants. Not all giants automatically revere their kind's primary deity, however. Many good cloud giants refuse to worship the deceitful Memnor, and a storm giant dwelling in the icy mountains of the north might pay more homage to Thrym than Stronmaus. Other giants feel a stronger connection to Annam's daughters, who include Hiatea, the huntress and home warden; Iallanis, goddess of love and peace; and Diancastra, an impetuous and arrogant trickster.",
-							"Some giants abandon their own gods and fall prey to demon cults, paying homage to Baphomet or Kostchtchie. To worship them or any other non-giant deity is a great sin against the ordning, and almost certain to make a giant an outcast."
+							"The patron god and father of the cloud giants is Memnor the Trickster, the cleverest and slyest of the giant deities. Cloud giants align themselves according to the aspects and exploits of Memnor that they most admire, with evil cloud giants emulating his deceitfulness and self-interest and good cloud giants emulating his intellect and silver-tongued speech. Family members usually align in the same direction."
+						]
+					},
+					{
+						"type": "entries",
+						"name": "Wealth and Power",
+						"entries": [
+							"A cloud giant earns its place in the ordning by the treasure it accumulates, the wealth it wears, and the gifts it bestows on other cloud giants.",
+							"However, value is only one part of the assessment. The extravagances a cloud giant wears or places about its home must also be beautiful or wondrous. Sacks of gold or gems are worth less to a cloud giant than the jewelry that might be crafted from those materials, creating treasures that bring esteem to a cloud giant's household.",
+							"Rather than steal from one another or fight over treasures, cloud giants are inveterate gamblers with a hunger for high risks and high rewards. They frequently bet on the outcome of events nominally outside their control, such as the lives of lesser creatures. Ordning ranks and kings' ransoms can be won and lost in bets over the military triumphs of humanoid nations. Fixing wagers by interfering in the conflict causes the loss of the bet, but such deceit is considered to be cheating only if it is discovered. Otherwise, it is cleverness honoring Memnor."
 						]
 					}
 				]
+			},
+			"_appendCopy": {
+				"name": "Giant",
+				"source": "MM"
 			}
 		},
 		{
@@ -2724,11 +2896,22 @@
 				"type": "entries",
 				"entries": [
 					"When a drow shows great promise, Lolth summons it to the Demonweb Pits for a test of faith and strength. Those that pass the test rise higher in the Spider Queen's favor. Those that fail are transformed into driders-a horrid hybrid of a drow and a giant spider that serves as a living reminder of Lolth's power. Only drow can be turned into driders, and the power to create these creatures resides with Lolth alone.",
-					"Scarred for Life. Drow transformed into driders return to the Material Plane as twisted and debased creatures. Driven by madness, they disappear into the Underdark to become hermits and hunters, either wandering alone or leading packs of giant spiders.",
-					"On rare occasion, a drider returns to the fringes of drow society despite its curse, most often to fulfill some longstanding vow or vendetta from its former life. Drow fear and shun the driders, holding them in lower esteem than slaves. However, they tolerate the presence of these creatures as living representatives of Lolth's will, and a reminder of the fate that awaits all who fail the Spider Queen.",
-					"Variant: Drider Spellcasting",
-					"Driders that were once drow spellcasters might retain their ability to cast spells. Such driders typically have a higher spellcasting ability (15 or 16) than other driders. Further, the drider gains the Spellcasting trait. A drider that was a drow divine spellcaster, therefore, could have a Wisdom of 16 (+3) and a Spellcasting trait as follows.",
-					"Spellcasting. The drider is a 7th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). The drider has the following spells prepared from the cleric spell list:\\rCantrips (at will): poison spray, thaumaturgy \\r1st level (4 slots): bane, detect magic, sanctuary \\r2nd level (3 slots): hold person, silence \\r3rd level (3 slots): clairvoyance, dispel magic \\r4th level (2 slots): divination, freedom of movement"
+					{
+						"type": "entries",
+						"name": "Scarred for Life",
+						"entries": [
+							"Drow transformed into driders return to the Material Plane as twisted and debased creatures. Driven by madness, they disappear into the Underdark to become hermits and hunters, either wandering alone or leading packs of giant spiders.",
+							"On rare occasion, a drider returns to the fringes of drow society despite its curse, most often to fulfill some longstanding vow or vendetta from its former life. Drow fear and shun the driders, holding them in lower esteem than slaves. However, they tolerate the presence of these creatures as living representatives of Lolth's will, and a reminder of the fate that awaits all who fail the Spider Queen."
+						]
+					},
+					{
+						"type": "inset",
+						"name": "Variant: Drider Spellcasting",
+						"entries": [
+							"Driders that were once drow spellcasters might retain their ability to cast spells. Such driders typically have a higher spellcasting ability (15 or 16) than other driders. Further, the drider gains the Spellcasting trait. A drider that was a drow divine spellcaster, therefore, could have a Wisdom of 16 (+3) and a Spellcasting trait as follows.",
+							"Spellcasting. The drider is a 7th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). The drider has the following spells prepared from the cleric spell list:\\rCantrips (at will): poison spray, thaumaturgy \\r1st level (4 slots): bane, detect magic, sanctuary \\r2nd level (3 slots): hold person, silence \\r3rd level (3 slots): clairvoyance, dispel magic \\r4th level (2 slots): divination, freedom of movement"
+						]
+					}
 				]
 			}
 		},
@@ -2988,20 +3171,12 @@
 			"entries": {
 				"type": "entries",
 				"entries": [
-					"Composed of earth and air, dust mephits are drawn to catacombs and find death morbidly fascinating.",
-					{
-						"type": "entries",
-						"name": "Mephits",
-						"entries": [
-							"Mephits are capricious, imp-like creatures native to the elemental planes. They come in six varieties, each one representing the mixture of two elements.",
-							"Ageless tricksters, mephits gather in large numbers on the Elemental Planes and in the Elemental Chaos. They also find their way to the Material Plane, where they prefer to dwell in places where their base elements are abundant. For example, a magma mephit is composed of earth and fire, and it favors volcanic lairs, while an ice mephit, which is composed of air and water, favors frigid locales.",
-							"Elemental Nature. A mephit doesn't require food, drink, or sleep.",
-							"Variant: Mephit Summoning",
-							"Some mephits can have an action option that allows them to summon other mephits.",
-							"Summon Mephits (1/Day). The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
-						]
-					}
+					"Composed of earth and air, dust mephits are drawn to catacombs and find death morbidly fascinating."
 				]
+			},
+			"_appendCopy": {
+				"name": "Mephit",
+				"source": "MM"
 			}
 		},
 		{
@@ -3020,20 +3195,12 @@
 				"type": "entries",
 				"entries": [
 					"An earth elemental plods forward like a walking hill, club-like arms of jagged stone swinging at its sides. Its head and body consist of dirt and stone, occasionally set with chunks of metal, gems, and bright minerals.",
-					"Earth elementals glide through rock and earth as though they were liquid. Earthbound creatures have much to fear from an earth elemental, since the elemental can pinpoint the precise location of any foe that stands on solid ground in its vicinity.",
-					{
-						"type": "entries",
-						"name": "Elementals",
-						"entries": [
-							"Elementals are incarnations of the elements that make up the universe: air, earth, fire, and water. Though little more than animated energy on their own planes of existence, they can be called on by spellcasters and powerful beings to take shape and perform tasks.",
-							"Living Elements. On its home plane, an elemental is a bodiless life force. Its dim consciousness manifests as a physical shape only when focused by the power of magic. A wild spirit of elemental force has no desire except to course through the element of its native plane. Like beasts of the Material Plane, these elemental spirits have no society or culture, and little sense of being.",
-							"Conjured by Magic. Certain spells and magic items can conjure an elemental, summoning it from the Inner Planes to the Material Plane. Elementals instinctively resent being pulled from their native planes and bound into service. A creature that summons an elemental must assert force of will to control it.",
-							"Bound and Shaped. Powerful magic can bind an elemental spirit into a material template that defines a specific use and function. Invisible stalkers are air elementals bound to a specific form, in the same way that water elementals can be shaped into water weirds.",
-							"The strength of the magic and materials that bind an elemental determines how well the elemental functions in a bound form. Golems are elemental spirits bound to physical forms, but weaker materials such as flesh and clay can't bind elemental power sufficiently. Durable materials such as stone and iron require stronger magic, which consequently binds an elemental more securely.",
-							"Elemental Nature. An elemental doesn't require air, food, drink, or sleep."
-						]
-					}
+					"Earth elementals glide through rock and earth as though they were liquid. Earthbound creatures have much to fear from an earth elemental, since the elemental can pinpoint the precise location of any foe that stands on solid ground in its vicinity."
 				]
+			},
+			"_appendCopy": {
+				"name": "Elemental",
+				"source": "MM"
 			}
 		},
 		{
@@ -3244,20 +3411,12 @@
 			"entries": {
 				"type": "entries",
 				"entries": [
-					"A faint humanoid shape threads through the core of this wild, moving flame. A fire elemental is a force of capricious devastation. Wherever it moves, it sets its surroundings ablaze, turning the world to ash, smoke, and cinders. Water can halt its destructive progress, causing the fire elemental to shrink back, hissing and smoking in pain and rage.",
-					{
-						"type": "entries",
-						"name": "Elementals",
-						"entries": [
-							"Elementals are incarnations of the elements that make up the universe: air, earth, fire, and water. Though little more than animated energy on their own planes of existence, they can be called on by spellcasters and powerful beings to take shape and perform tasks.",
-							"Living Elements. On its home plane, an elemental is a bodiless life force. Its dim consciousness manifests as a physical shape only when focused by the power of magic. A wild spirit of elemental force has no desire except to course through the element of its native plane. Like beasts of the Material Plane, these elemental spirits have no society or culture, and little sense of being.",
-							"Conjured by Magic. Certain spells and magic items can conjure an elemental, summoning it from the Inner Planes to the Material Plane. Elementals instinctively resent being pulled from their native planes and bound into service. A creature that summons an elemental must assert force of will to control it.",
-							"Bound and Shaped. Powerful magic can bind an elemental spirit into a material template that defines a specific use and function. Invisible stalkers are air elementals bound to a specific form, in the same way that water elementals can be shaped into water weirds.",
-							"The strength of the magic and materials that bind an elemental determines how well the elemental functions in a bound form. Golems are elemental spirits bound to physical forms, but weaker materials such as flesh and clay can't bind elemental power sufficiently. Durable materials such as stone and iron require stronger magic, which consequently binds an elemental more securely.",
-							"Elemental Nature. An elemental doesn't require air, food, drink, or sleep."
-						]
-					}
+					"A faint humanoid shape threads through the core of this wild, moving flame. A fire elemental is a force of capricious devastation. Wherever it moves, it sets its surroundings ablaze, turning the world to ash, smoke, and cinders. Water can halt its destructive progress, causing the fire elemental to shrink back, hissing and smoking in pain and rage."
 				]
+			},
+			"_appendCopy": {
+				"name": "Elemental",
+				"source": "MM"
 			}
 		},
 		{
@@ -3290,45 +3449,45 @@
 				"type": "entries",
 				"entries": [
 					"Master crafters and organized warriors, fire giants dwell among volcanoes, lava floes, and rocky mountains. They are ruthless militaristic brutes whose mastery of metalwork is legendary.",
-					"Fire Forged. Fire giant fortresses are built around and inside volcanoes or near magma-filled caverns. The blistering heat of their homes fuels the fire giants' forges, and causes the iron of their fortress walls to glow a comforting orange. In lands far removed from volcanic heat, fire giants mine coal to burn. Traditional smithies occupy places of honor in their demesnes, and the giants' stony fortresses constantly belch plumes of sooty smoke. In more remote outposts, fire giants burn wood to keep their forge fires lit, deforesting leagues of land in all directions.",
-					"Fire giants shun cold as much as their cousins the frost giants hate heat. They can adapt to cold environments with effort, though, keeping their hearth fires burning bright and wearing heavy woolen clothing and furs to stay warm.",
-					"Martial Experts. From birth, a fire giant is taught to embrace a legacy of war. At the cradle, its parents chant songs of battle. As children, fire giants play at war, hurling igneous rocks at one another across the banks of magma rivers. In later years, formal martial training becomes an integral part of life in the giants' fortresses and underground realms of smoke and ash.",
-					"The fire giants' songs are odes of battles lost and won, while their dances are martial formations of pounding feet that resound like smiths' hammers throughout their smoky halls.",
-					"Just as fire giants pass down their knowledge of crafting from generation to generation, their renowned fighting prowess comes not from wild fury but from endless discipline and training. Enemies make the mistake of underestimating fire giants based on their brutish manner, learning too late that these giants live for combat and can be shrewd tacticians.",
-					"Feudal Lords. Humanoids conquered in war become serfs to the fire giants. The serfs work the farms and fields on the outskirts of fire giant halls and fortresses, raising livestock and harvesting fields whose bounty is almost entirely tithed to the fire giant kings.",
-					"Fire giant crafters work through insight and experience rather than writing or arithmetic. Though most fire giants place little worth on such frivolousness, they sometimes keep slaves at court who are versed in such skills. Serfs not destined for court or the fields (especially dwarves) are taken to the fire giants' mountainous realms to mine ore and gemstones from deep within the earth.",
-					"Fire giants low in the ordning manage the mine tunnels and the slaves that toil there, few of which survive the difficult and dangerous work for long. Though fire giants are skilled in the engineering of mine tunnels and the gathering of ore, they place less importance on the safety of their slaves than on smelting and working the bounty those slaves produce.",
-					"Skilled Artisans. Fire giants have a fearsome reputation as soldiers and conquerors, and for their ability to burn, plunder, and destroy. Yet among the giants, fire giants produce the greatest crafters and artists. They excel at smelting and smith work, as they do at the engineering of metal and stone, and the quality of their artistry shows even in their implements of destruction and their weapons of war.",
-					"Fire giants strive to build the strongest fortresses and most potent siege weapons. They experiment with alloys to create the hardest armor, then forge the swords that can pierce it. Such work requires brawn and brains in equal measure, and fire giants high in the ordning tend to be the smartest and strongest of their kind.",
 					{
 						"type": "entries",
-						"name": "Giants",
+						"name": "Fire Forged",
 						"entries": [
-							"Ancient empires once cast long shadows over a world that quaked beneath the giants' feet. In those lost days, these towering figures were dragon slayers, dreamers, crafters, and kings, but their kind fell from glory long ago. However, even divided among secluded clans scattered throughout the world, the giants maintain the customs and traditions of old.",
-							"Old as Legend. In remote regions of the world, the last remaining plinths, monoliths, and statues of the great giant empires bow their heads in desolate obscurity. Where once those empires sprawled across all lands, now the giants dwell in isolated tribes and clans.",
-							"Giants are almost as old as dragons, which were still young when the giants' heavy feet first shook the foundations of the world. As they spread across new lands, giants and dragons fought bitter generational wars that nearly brought both sides low. No living giant remembers what started the conflict, but myths and tales of their race's glorious dawn are still sung in their steadings and holdfasts, vilifying the primeval wyrms. Giants and dragons continue to harbor grudges against one another, and it is seldom that they will meet or occupy the same area without a fight."
+							"Fire giant fortresses are built around and inside volcanoes or near magma-filled caverns. The blistering heat of their homes fuels the fire giants' forges, and causes the iron of their fortress walls to glow a comforting orange. In lands far removed from volcanic heat, fire giants mine coal to burn. Traditional smithies occupy places of honor in their demesnes, and the giants' stony fortresses constantly belch plumes of sooty smoke. In more remote outposts, fire giants burn wood to keep their forge fires lit, deforesting leagues of land in all directions.",
+							"Fire giants shun cold as much as their cousins the frost giants hate heat. They can adapt to cold environments with effort, though, keeping their hearth fires burning bright and wearing heavy woolen clothing and furs to stay warm."
 						]
 					},
 					{
 						"type": "entries",
-						"name": "The Ordning",
+						"name": "Martial Experts",
 						"entries": [
-							"Each of the main giant races-the cloud, fire, frost, hill, stone, and storm giants-are related by common elements of history, religion, and culture. They view one another as kindred, keeping any inherent animosity over territory and ambition to a minimum.",
-							"Giants belong to a caste structure called the ordning. Based on social class and highly organized, the ordning assigns a social rank to each giant. By understanding its place in the ordning, a giant knows which other giants are inferior or superior to it, since no two giants are equal. Each of the giant races analyzes a different combination of skills or qualities to determine the ordning. Giants make excelling in these qualities the purpose of their lives.",
-							"At the highest level of the ordning, the races of the giants are also ranked according to status. Storm giants are the highest in the ordning, followed by cloud giants, fire giants, frost giants, stone giants, hill giants, and finally giant kin such as fomorians, ettins, and ogres.",
-							"Regardless of a giant's rank among its own race, the chief of a hill giant tribe is inferior to the most common of stone giants. The lowest ranked giant of any type is superior to the highest ranked giant of an inferior type. It isn't considered evil to disrespect or even betray a giant of another type, merely rude."
+							"From birth, a fire giant is taught to embrace a legacy of war. At the cradle, its parents chant songs of battle. As children, fire giants play at war, hurling igneous rocks at one another across the banks of magma rivers. In later years, formal martial training becomes an integral part of life in the giants' fortresses and underground realms of smoke and ash.",
+							"The fire giants' songs are odes of battles lost and won, while their dances are martial formations of pounding feet that resound like smiths' hammers throughout their smoky halls.",
+							"Just as fire giants pass down their knowledge of crafting from generation to generation, their renowned fighting prowess comes not from wild fury but from endless discipline and training. Enemies make the mistake of underestimating fire giants based on their brutish manner, learning too late that these giants live for combat and can be shrewd tacticians."
 						]
 					},
 					{
 						"type": "entries",
-						"name": "Giant Gods",
+						"name": "Feudal Lords",
 						"entries": [
-							"When the giants' ancient empires fell, Annam, father of all giants, forsook his children and the world. He swore never to look upon either again until the giants had returned to their glory and reclaimed their birthright as rulers of the world. As a result, giants pray not to Annam but to his divine children, along with a host of hero-deities and godly villains that make up the giants' pantheon.",
-							"Chief among these gods are the children of Annam, whose sons represent each type of giant: Stronmaus for storm giants, Memnor for cloud giants, Skoraeus Stonebones for stone giants, Thrym for frost giants, Surtur for fire giants, and Grolantor for hill giants. Not all giants automatically revere their kind's primary deity, however. Many good cloud giants refuse to worship the deceitful Memnor, and a storm giant dwelling in the icy mountains of the north might pay more homage to Thrym than Stronmaus. Other giants feel a stronger connection to Annam's daughters, who include Hiatea, the huntress and home warden; Iallanis, goddess of love and peace; and Diancastra, an impetuous and arrogant trickster.",
-							"Some giants abandon their own gods and fall prey to demon cults, paying homage to Baphomet or Kostchtchie. To worship them or any other non-giant deity is a great sin against the ordning, and almost certain to make a giant an outcast."
+							"Humanoids conquered in war become serfs to the fire giants. The serfs work the farms and fields on the outskirts of fire giant halls and fortresses, raising livestock and harvesting fields whose bounty is almost entirely tithed to the fire giant kings.",
+							"Fire giant crafters work through insight and experience rather than writing or arithmetic. Though most fire giants place little worth on such frivolousness, they sometimes keep slaves at court who are versed in such skills. Serfs not destined for court or the fields (especially dwarves) are taken to the fire giants' mountainous realms to mine ore and gemstones from deep within the earth.",
+							"Fire giants low in the ordning manage the mine tunnels and the slaves that toil there, few of which survive the difficult and dangerous work for long. Though fire giants are skilled in the engineering of mine tunnels and the gathering of ore, they place less importance on the safety of their slaves than on smelting and working the bounty those slaves produce."
+						]
+					},
+					{
+						"type": "entries",
+						"name": "Skilled Artisans",
+						"entries": [
+							"Fire giants have a fearsome reputation as soldiers and conquerors, and for their ability to burn, plunder, and destroy. Yet among the giants, fire giants produce the greatest crafters and artists. They excel at smelting and smith work, as they do at the engineering of metal and stone, and the quality of their artistry shows even in their implements of destruction and their weapons of war.",
+							"Fire giants strive to build the strongest fortresses and most potent siege weapons. They experiment with alloys to create the hardest armor, then forge the swords that can pierce it. Such work requires brawn and brains in equal measure, and fire giants high in the ordning tend to be the smartest and strongest of their kind."
 						]
 					}
 				]
+			},
+			"_appendCopy": {
+				"name": "Giant",
+				"source": "MM"
 			}
 		},
 		{
@@ -3515,42 +3674,42 @@
 				"type": "entries",
 				"entries": [
 					"Gigantic reavers from the freezing lands beyond civilization, frost giants are fierce, hardy warriors that survive on the spoils of their raids and pillaging. They respect only brute strength and skill in battle, demonstrating both with their scars and the grisly trophies they take from their enemies.",
-					"Hearts of Ice. Frost giants are creatures of ice and snow. Their hair and beards are pale white or light blue, matted with frost and clattering with icicles. Their flesh is as blue as glacial ice.",
-					"Frost giants dwell in high peaks and glacial rifts where the sun hides its golden head by winter. Crops don't grow in their frozen homelands, and they keep little livestock beyond what they capture in their raids against civilized lands. They hunt the wild game of the tundra and mountains but don't cook it, since meat from a fresh kill tastes sufficiently hot to their palate.",
-					"Reavers of the Storm. The war horns of the frost giants howl as they march from their ice fortresses and glacial rifts amid the howling blizzard. When that storm clears, villages and steadings lay in ruins, ravens descending to feed on the corpses of any creatures foolish or unlucky enough to stand in the giants' path.",
-					"Inns and taverns suffer the brunt of the damage, their cellars gutted and their casks of ale and mead gone. Smithies are likewise toppled, their iron and steel claimed. Curiously undisturbed are the houses of moneylenders and wealthy citizens, for the reavers have little use for coins or baubles. Frost giants prize gems and jewelry large enough to be worn and noticed. However, even those treasures are most often saved for trading opportunities with other giants more adept at crafting metal weapons and armor.",
-					"Rulers by Might. Frost giants respect brute strength above all else, and a frost giant's place in the ordning depends on evidence of physical might, such as superior musculature, scars from battles of renown, or trophies fashioned from the bodies of slain enemies. Tasks such as hunting, childrearing, and crafting are given to giants based on their physical strength and hardiness.",
-					"When frost giants of different clans meet and their status is unclear, they wrestle for dominance. Such meetings might resemble festivals where giants cheer on their champions, making bold boasts and challenges. At other times, the informal ceremony can become a chaotic free-for-all where both clans rush into a melee that fells trees, shatters the ice on frozen lakes, and causes avalanches on the snowy mountainsides.",
-					"Make War, Not Goods. Though frost giants consider the menial crafting of goods beneath them, carving and leatherwork are valued skills. They make their clothing from the skins and bones of beasts, and carve bone or ivory into jewelry and the handles of weapons and tools. They reuse the weapons and armor of their smaller foes, stringing shields into scale armor and lashing sword blades to wooden hafts to make giant-sized spears. The greatest battle trophies come from conquered dragons, and the greatest frost giant jarls wear armor of dragon scales or wield picks and mauls made of a dragon's teeth or claws.",
 					{
 						"type": "entries",
-						"name": "Giants",
+						"name": "Hearts of Ice",
 						"entries": [
-							"Ancient empires once cast long shadows over a world that quaked beneath the giants' feet. In those lost days, these towering figures were dragon slayers, dreamers, crafters, and kings, but their kind fell from glory long ago. However, even divided among secluded clans scattered throughout the world, the giants maintain the customs and traditions of old.",
-							"Old as Legend. In remote regions of the world, the last remaining plinths, monoliths, and statues of the great giant empires bow their heads in desolate obscurity. Where once those empires sprawled across all lands, now the giants dwell in isolated tribes and clans.",
-							"Giants are almost as old as dragons, which were still young when the giants' heavy feet first shook the foundations of the world. As they spread across new lands, giants and dragons fought bitter generational wars that nearly brought both sides low. No living giant remembers what started the conflict, but myths and tales of their race's glorious dawn are still sung in their steadings and holdfasts, vilifying the primeval wyrms. Giants and dragons continue to harbor grudges against one another, and it is seldom that they will meet or occupy the same area without a fight."
+							"Frost giants are creatures of ice and snow. Their hair and beards are pale white or light blue, matted with frost and clattering with icicles. Their flesh is as blue as glacial ice.",
+							"Frost giants dwell in high peaks and glacial rifts where the sun hides its golden head by winter. Crops don't grow in their frozen homelands, and they keep little livestock beyond what they capture in their raids against civilized lands. They hunt the wild game of the tundra and mountains but don't cook it, since meat from a fresh kill tastes sufficiently hot to their palate."
 						]
 					},
 					{
 						"type": "entries",
-						"name": "The Ordning",
+						"name": "Reavers of the Storm",
 						"entries": [
-							"Each of the main giant races-the cloud, fire, frost, hill, stone, and storm giants-are related by common elements of history, religion, and culture. They view one another as kindred, keeping any inherent animosity over territory and ambition to a minimum.",
-							"Giants belong to a caste structure called the ordning. Based on social class and highly organized, the ordning assigns a social rank to each giant. By understanding its place in the ordning, a giant knows which other giants are inferior or superior to it, since no two giants are equal. Each of the giant races analyzes a different combination of skills or qualities to determine the ordning. Giants make excelling in these qualities the purpose of their lives.",
-							"At the highest level of the ordning, the races of the giants are also ranked according to status. Storm giants are the highest in the ordning, followed by cloud giants, fire giants, frost giants, stone giants, hill giants, and finally giant kin such as fomorians, ettins, and ogres.",
-							"Regardless of a giant's rank among its own race, the chief of a hill giant tribe is inferior to the most common of stone giants. The lowest ranked giant of any type is superior to the highest ranked giant of an inferior type. It isn't considered evil to disrespect or even betray a giant of another type, merely rude."
+							"The war horns of the frost giants howl as they march from their ice fortresses and glacial rifts amid the howling blizzard. When that storm clears, villages and steadings lay in ruins, ravens descending to feed on the corpses of any creatures foolish or unlucky enough to stand in the giants' path.",
+							"Inns and taverns suffer the brunt of the damage, their cellars gutted and their casks of ale and mead gone. Smithies are likewise toppled, their iron and steel claimed. Curiously undisturbed are the houses of moneylenders and wealthy citizens, for the reavers have little use for coins or baubles. Frost giants prize gems and jewelry large enough to be worn and noticed. However, even those treasures are most often saved for trading opportunities with other giants more adept at crafting metal weapons and armor."
 						]
 					},
 					{
 						"type": "entries",
-						"name": "Giant Gods",
+						"name": "Rulers by Might",
 						"entries": [
-							"When the giants' ancient empires fell, Annam, father of all giants, forsook his children and the world. He swore never to look upon either again until the giants had returned to their glory and reclaimed their birthright as rulers of the world. As a result, giants pray not to Annam but to his divine children, along with a host of hero-deities and godly villains that make up the giants' pantheon.",
-							"Chief among these gods are the children of Annam, whose sons represent each type of giant: Stronmaus for storm giants, Memnor for cloud giants, Skoraeus Stonebones for stone giants, Thrym for frost giants, Surtur for fire giants, and Grolantor for hill giants. Not all giants automatically revere their kind's primary deity, however. Many good cloud giants refuse to worship the deceitful Memnor, and a storm giant dwelling in the icy mountains of the north might pay more homage to Thrym than Stronmaus. Other giants feel a stronger connection to Annam's daughters, who include Hiatea, the huntress and home warden; Iallanis, goddess of love and peace; and Diancastra, an impetuous and arrogant trickster.",
-							"Some giants abandon their own gods and fall prey to demon cults, paying homage to Baphomet or Kostchtchie. To worship them or any other non-giant deity is a great sin against the ordning, and almost certain to make a giant an outcast."
+							"Frost giants respect brute strength above all else, and a frost giant's place in the ordning depends on evidence of physical might, such as superior musculature, scars from battles of renown, or trophies fashioned from the bodies of slain enemies. Tasks such as hunting, childrearing, and crafting are given to giants based on their physical strength and hardiness.",
+							"When frost giants of different clans meet and their status is unclear, they wrestle for dominance. Such meetings might resemble festivals where giants cheer on their champions, making bold boasts and challenges. At other times, the informal ceremony can become a chaotic free-for-all where both clans rush into a melee that fells trees, shatters the ice on frozen lakes, and causes avalanches on the snowy mountainsides."
+						]
+					},
+					{
+						"type": "entries",
+						"name": "Make War, Not Goods",
+						"entries": [
+							"Though frost giants consider the menial crafting of goods beneath them, carving and leatherwork are valued skills. They make their clothing from the skins and bones of beasts, and carve bone or ivory into jewelry and the handles of weapons and tools. They reuse the weapons and armor of their smaller foes, stringing shields into scale armor and lashing sword blades to wooden hafts to make giant-sized spears. The greatest battle trophies come from conquered dragons, and the greatest frost giant jarls wear armor of dragon scales or wield picks and mauls made of a dragon's teeth or claws."
 						]
 					}
 				]
+			},
+			"_appendCopy": {
+				"name": "Giant",
+				"source": "MM"
 			}
 		},
 		{
@@ -4794,45 +4953,51 @@
 				"type": "entries",
 				"entries": [
 					"Hill giants are selfish, dimwitted brutes that hunt, forage, and raid in constant search of food. They blunder through hills and forests devouring what they can, bullying smaller creatures into feeding them. Their laziness and dullness would long ago have spelled their end if not for their formidable size and strength.",
-					"Primitive. Hill giants dwell in hills and mountain valleys across the world, congregating in steadings built of rough timber or in clusters of well-defended mud-and-wattle huts. Their skins are tan from lives spent lumbering up and down the hilly slopes and dozing beneath the sun. Their weapons are uprooted trees and rocks pulled from the earth. The sweat of their bodies adds to the reek of the crude animal skins they wear, poorly stitched together with hair and leather thongs.",
-					"Bigger Means Better. In a hill giant's world, humanoids and animals are easy prey that can be hunted with impunity. Creatures such as dragons and other giants are tough adversaries. Hill giants equate size with power.",
-					"Hill giants don't realize they follow an ordning. They know only that other giants are larger and stronger than they are, which means they are to be obeyed. A hill giant tribe's chief is usually the tallest and fattest giant that can still move about. Only on rare occasion does a hill giant with more brains than bulk use its cunning to gain the favor of giants of higher status, cleverly subverting the social order.",
-					"Voracious Eaters. With nothing else to occupy them, hill giants eat as often as possible. A hill giant hunts and forages alone or with a dire wolf companion, so as to not have to share with other tribe members. The giant eats anything that isn't obviously deadly, such as creatures known to be poisonous. Rotten meat is fair game, though, as are decaying plants and even mud.",
-					"Farmers fear and loathe hill giants. Where a predator such as an ankheg might burrow through fields and consume a cow or two before being driven off, a hill giant will consume a whole herd of cattle before moving on to sheep, goats, and chickens, then tearing into fruits, vegetables, and grain. If a farm family is at hand, the giant might snack on them too.",
-					"Stupid and Deadly. The hill giants' ability to digest nearly anything has allowed them to survive for eons as savages, eating and breeding in the hills like animals. They have never needed to adapt and change, so their minds and emotions remain simple and undeveloped.",
-					"With no culture of their own, hill giants ape the traditions of creatures they manage to observe for a time before eating them. They don't think about their own size and strength, however. Tribes of hill giants attempting to imitate elves have been known to topple entire forests by trying to live in trees. Others attempting to take over humanoid towns or villages get only as far as the doors and windows of a building, taking out its walls and roof as they attempt to enter.",
-					"In conversation, hill giants are blunt and direct, and they have little concept of deception. A hill giant might be fooled into running from another giant if a number of villagers cover themselves in blankets and stand on one another's shoulders holding a giant-painted pumpkin head. Reasoning with a hill giant is futile, although clever creatures can sometimes encourage a giant to take actions that benefit them.",
-					"Raging Bullies. A hill giant that feels as though it has been deceived, insulted, or made into a fool vents its terrible wrath on anything it encounters. Even after smashing those who offended it into pulp, the giant rampages until its rage abates, it notices something more interesting, or it grows hungry.",
-					"If a hill giant proclaims itself king over a territory where other humanoids live, it rules strictly by terror and tyranny. Its decisions shift with its mood, and if it forgets the title it bestowed upon itself, it might eat its subjects on a whim.",
 					{
 						"type": "entries",
-						"name": "Giants",
+						"name": "Primitive",
 						"entries": [
-							"Ancient empires once cast long shadows over a world that quaked beneath the giants' feet. In those lost days, these towering figures were dragon slayers, dreamers, crafters, and kings, but their kind fell from glory long ago. However, even divided among secluded clans scattered throughout the world, the giants maintain the customs and traditions of old.",
-							"Old as Legend. In remote regions of the world, the last remaining plinths, monoliths, and statues of the great giant empires bow their heads in desolate obscurity. Where once those empires sprawled across all lands, now the giants dwell in isolated tribes and clans.",
-							"Giants are almost as old as dragons, which were still young when the giants' heavy feet first shook the foundations of the world. As they spread across new lands, giants and dragons fought bitter generational wars that nearly brought both sides low. No living giant remembers what started the conflict, but myths and tales of their race's glorious dawn are still sung in their steadings and holdfasts, vilifying the primeval wyrms. Giants and dragons continue to harbor grudges against one another, and it is seldom that they will meet or occupy the same area without a fight."
+							"Hill giants dwell in hills and mountain valleys across the world, congregating in steadings built of rough timber or in clusters of well-defended mud-and-wattle huts. Their skins are tan from lives spent lumbering up and down the hilly slopes and dozing beneath the sun. Their weapons are uprooted trees and rocks pulled from the earth. The sweat of their bodies adds to the reek of the crude animal skins they wear, poorly stitched together with hair and leather thongs."
 						]
 					},
 					{
 						"type": "entries",
-						"name": "The Ordning",
+						"name": "Bigger Means Better",
 						"entries": [
-							"Each of the main giant races-the cloud, fire, frost, hill, stone, and storm giants-are related by common elements of history, religion, and culture. They view one another as kindred, keeping any inherent animosity over territory and ambition to a minimum.",
-							"Giants belong to a caste structure called the ordning. Based on social class and highly organized, the ordning assigns a social rank to each giant. By understanding its place in the ordning, a giant knows which other giants are inferior or superior to it, since no two giants are equal. Each of the giant races analyzes a different combination of skills or qualities to determine the ordning. Giants make excelling in these qualities the purpose of their lives.",
-							"At the highest level of the ordning, the races of the giants are also ranked according to status. Storm giants are the highest in the ordning, followed by cloud giants, fire giants, frost giants, stone giants, hill giants, and finally giant kin such as fomorians, ettins, and ogres.",
-							"Regardless of a giant's rank among its own race, the chief of a hill giant tribe is inferior to the most common of stone giants. The lowest ranked giant of any type is superior to the highest ranked giant of an inferior type. It isn't considered evil to disrespect or even betray a giant of another type, merely rude."
+							"In a hill giant's world, humanoids and animals are easy prey that can be hunted with impunity. Creatures such as dragons and other giants are tough adversaries. Hill giants equate size with power.",
+							"Hill giants don't realize they follow an ordning. They know only that other giants are larger and stronger than they are, which means they are to be obeyed. A hill giant tribe's chief is usually the tallest and fattest giant that can still move about. Only on rare occasion does a hill giant with more brains than bulk use its cunning to gain the favor of giants of higher status, cleverly subverting the social order."
 						]
 					},
 					{
 						"type": "entries",
-						"name": "Giant Gods",
+						"name": "Voracious Eaters",
 						"entries": [
-							"When the giants' ancient empires fell, Annam, father of all giants, forsook his children and the world. He swore never to look upon either again until the giants had returned to their glory and reclaimed their birthright as rulers of the world. As a result, giants pray not to Annam but to his divine children, along with a host of hero-deities and godly villains that make up the giants' pantheon.",
-							"Chief among these gods are the children of Annam, whose sons represent each type of giant: Stronmaus for storm giants, Memnor for cloud giants, Skoraeus Stonebones for stone giants, Thrym for frost giants, Surtur for fire giants, and Grolantor for hill giants. Not all giants automatically revere their kind's primary deity, however. Many good cloud giants refuse to worship the deceitful Memnor, and a storm giant dwelling in the icy mountains of the north might pay more homage to Thrym than Stronmaus. Other giants feel a stronger connection to Annam's daughters, who include Hiatea, the huntress and home warden; Iallanis, goddess of love and peace; and Diancastra, an impetuous and arrogant trickster.",
-							"Some giants abandon their own gods and fall prey to demon cults, paying homage to Baphomet or Kostchtchie. To worship them or any other non-giant deity is a great sin against the ordning, and almost certain to make a giant an outcast."
+							"With nothing else to occupy them, hill giants eat as often as possible. A hill giant hunts and forages alone or with a dire wolf companion, so as to not have to share with other tribe members. The giant eats anything that isn't obviously deadly, such as creatures known to be poisonous. Rotten meat is fair game, though, as are decaying plants and even mud.",
+							"Farmers fear and loathe hill giants. Where a predator such as an ankheg might burrow through fields and consume a cow or two before being driven off, a hill giant will consume a whole herd of cattle before moving on to sheep, goats, and chickens, then tearing into fruits, vegetables, and grain. If a farm family is at hand, the giant might snack on them too."
+						]
+					},
+					{
+						"type": "entries",
+						"name": "Stupid and Deadly",
+						"entries": [
+							"The hill giants' ability to digest nearly anything has allowed them to survive for eons as savages, eating and breeding in the hills like animals. They have never needed to adapt and change, so their minds and emotions remain simple and undeveloped.",
+							"With no culture of their own, hill giants ape the traditions of creatures they manage to observe for a time before eating them. They don't think about their own size and strength, however. Tribes of hill giants attempting to imitate elves have been known to topple entire forests by trying to live in trees. Others attempting to take over humanoid towns or villages get only as far as the doors and windows of a building, taking out its walls and roof as they attempt to enter.",
+							"In conversation, hill giants are blunt and direct, and they have little concept of deception. A hill giant might be fooled into running from another giant if a number of villagers cover themselves in blankets and stand on one another's shoulders holding a giant-painted pumpkin head. Reasoning with a hill giant is futile, although clever creatures can sometimes encourage a giant to take actions that benefit them."
+						]
+					},
+					{
+						"type": "entries",
+						"name": "Raging Bullies",
+						"entries": [
+							"A hill giant that feels as though it has been deceived, insulted, or made into a fool vents its terrible wrath on anything it encounters. Even after smashing those who offended it into pulp, the giant rampages until its rage abates, it notices something more interesting, or it grows hungry.",
+					"If a hill giant proclaims itself king over a territory where other humanoids live, it rules strictly by terror and tyranny. Its decisions shift with its mood, and if it forgets the title it bestowed upon itself, it might eat its subjects on a whim."
 						]
 					}
 				]
+			},
+			"_appendCopy": {
+				"name": "Giant",
+				"source": "MM"
 			}
 		},
 		{
@@ -5072,20 +5237,12 @@
 			"entries": {
 				"type": "entries",
 				"entries": [
-					"Comprising frigid air and water, ice mephits are aloof and cold, surpassing all other mephits in pitiless cruelty.",
-					{
-						"type": "entries",
-						"name": "Mephits",
-						"entries": [
-							"Mephits are capricious, imp-like creatures native to the elemental planes. They come in six varieties, each one representing the mixture of two elements.",
-							"Ageless tricksters, mephits gather in large numbers on the Elemental Planes and in the Elemental Chaos. They also find their way to the Material Plane, where they prefer to dwell in places where their base elements are abundant. For example, a magma mephit is composed of earth and fire, and it favors volcanic lairs, while an ice mephit, which is composed of air and water, favors frigid locales.",
-							"Elemental Nature. A mephit doesn't require food, drink, or sleep.",
-							"Variant: Mephit Summoning",
-							"Some mephits can have an action option that allows them to summon other mephits.",
-							"Summon Mephits (1/Day). The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
-						]
-					}
+					"Comprising frigid air and water, ice mephits are aloof and cold, surpassing all other mephits in pitiless cruelty"
 				]
+			},
+			"_appendCopy": {
+				"name": "Mephit",
+				"source": "MM"
 			}
 		},
 		{
@@ -5558,20 +5715,12 @@
 			"entries": {
 				"type": "entries",
 				"entries": [
-					"Composed of earth and fire, magma mephits glow a dull red color as they perspire beads of molten lava. They are slow to comprehend the meaning of others' words and actions.",
-					{
-						"type": "entries",
-						"name": "Mephits",
-						"entries": [
-							"Mephits are capricious, imp-like creatures native to the elemental planes. They come in six varieties, each one representing the mixture of two elements.",
-							"Ageless tricksters, mephits gather in large numbers on the Elemental Planes and in the Elemental Chaos. They also find their way to the Material Plane, where they prefer to dwell in places where their base elements are abundant. For example, a magma mephit is composed of earth and fire, and it favors volcanic lairs, while an ice mephit, which is composed of air and water, favors frigid locales.",
-							"Elemental Nature. A mephit doesn't require food, drink, or sleep.",
-							"Variant: Mephit Summoning",
-							"Some mephits can have an action option that allows them to summon other mephits.",
-							"Summon Mephits (1/Day). The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
-						]
-					}
+					"Composed of earth and fire, magma mephits glow a dull red color as they perspire beads of molten lava. They are slow to comprehend the meaning of others' words and actions."
 				]
+			},
+			"_appendCopy": {
+				"name": "Mephit",
+				"source": "MM"
 			}
 		},
 		{
@@ -5986,20 +6135,12 @@
 			"entries": {
 				"type": "entries",
 				"entries": [
-					"Mud mephits are slow, unctuous creatures of earth and water. They drone their complaints to all who will listen, and beg incessantly for attention and treasure.",
-					{
-						"type": "entries",
-						"name": "Mephits",
-						"entries": [
-							"Mephits are capricious, imp-like creatures native to the elemental planes. They come in six varieties, each one representing the mixture of two elements.",
-							"Ageless tricksters, mephits gather in large numbers on the Elemental Planes and in the Elemental Chaos. They also find their way to the Material Plane, where they prefer to dwell in places where their base elements are abundant. For example, a magma mephit is composed of earth and fire, and it favors volcanic lairs, while an ice mephit, which is composed of air and water, favors frigid locales.",
-							"Elemental Nature. A mephit doesn't require food, drink, or sleep.",
-							"Variant: Mephit Summoning",
-							"Some mephits can have an action option that allows them to summon other mephits.",
-							"Summon Mephits (1/Day). The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
-						]
-					}
+					"Mud mephits are slow, unctuous creatures of earth and water. They drone their complaints to all who will listen, and beg incessantly for attention and treasure."
 				]
+			},
+			"_appendCopy": {
+				"name": "Mephit",
+				"source": "MM"
 			}
 		},
 		{
@@ -7720,20 +7861,12 @@
 			"entries": {
 				"type": "entries",
 				"entries": [
-					"Smoke mephits are crude, lazy creatures of air and fire that billow smoke constantly. They rarely speak the truth and love to mock and mislead other creatures.",
-					{
-						"type": "entries",
-						"name": "Mephits",
-						"entries": [
-							"Mephits are capricious, imp-like creatures native to the elemental planes. They come in six varieties, each one representing the mixture of two elements.",
-							"Ageless tricksters, mephits gather in large numbers on the Elemental Planes and in the Elemental Chaos. They also find their way to the Material Plane, where they prefer to dwell in places where their base elements are abundant. For example, a magma mephit is composed of earth and fire, and it favors volcanic lairs, while an ice mephit, which is composed of air and water, favors frigid locales.",
-							"Elemental Nature. A mephit doesn't require food, drink, or sleep.",
-							"Variant: Mephit Summoning",
-							"Some mephits can have an action option that allows them to summon other mephits.",
-							"Summon Mephits (1/Day). The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
-						]
-					}
+					"Smoke mephits are crude, lazy creatures of air and fire that billow smoke constantly. They rarely speak the truth and love to mock and mislead other creatures."
 				]
+			},
+			"_appendCopy": {
+				"name": "Mephit",
+				"source": "MM"
 			}
 		},
 		{
@@ -7919,20 +8052,12 @@
 			"entries": {
 				"type": "entries",
 				"entries": [
-					"Composed of fire and water, steam mephits leave trails of hot water wherever they go, and they hiss with tendrils of steam. Bossy and hypersensitive, they are the self-appointed overlords of all mephits.",
-					{
-						"type": "entries",
-						"name": "Mephits",
-						"entries": [
-							"Mephits are capricious, imp-like creatures native to the elemental planes. They come in six varieties, each one representing the mixture of two elements.",
-							"Ageless tricksters, mephits gather in large numbers on the Elemental Planes and in the Elemental Chaos. They also find their way to the Material Plane, where they prefer to dwell in places where their base elements are abundant. For example, a magma mephit is composed of earth and fire, and it favors volcanic lairs, while an ice mephit, which is composed of air and water, favors frigid locales.",
-							"Elemental Nature. A mephit doesn't require food, drink, or sleep.",
-							"Variant: Mephit Summoning",
-							"Some mephits can have an action option that allows them to summon other mephits.",
-							"Summon Mephits (1/Day). The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
-						]
-					}
+					"Composed of fire and water, steam mephits leave trails of hot water wherever they go, and they hiss with tendrils of steam. Bossy and hypersensitive, they are the self-appointed overlords of all mephits."
 				]
+			},
+			"_appendCopy": {
+				"name": "Mephit",
+				"source": "MM"
 			}
 		},
 		{
@@ -7986,42 +8111,42 @@
 				"type": "entries",
 				"entries": [
 					"Stone giants are reclusive, quiet, and peaceful as long as they are left alone. Their granite-gray skin, gaunt features, and black, sunken eyes endow stone giants with a stern countenance. They are private creatures, hiding their lives and art away from the world.",
-					"Inhabitants of a Stone World. Secluded caves are the homes of the stone giants. Cavern networks are their towns, rocky tunnels their roads, and underground streams their waterways. Isolated mountain ranges are their continents, with the vast spans of land between seen as oceans that the stone giants only rarely cross.",
-					"In their dark, quiet caves, stone giants wordlessly chip away at elaborate carvings, measuring time in the echoing drip of water into cavern pools. In the deepest chambers of a stone giant settlement, far from the chittering of bats or the patrols paced out by the giants' cave bear companions, are holy places where silence and darkness are complete. Stone takes on its most sacred quality in these cavern cathedrals, their buttresses and columns carved with a beauty that shames the legendary stone craft of the dwarves.",
-					"Carvers and Seers. Among stone giants, artistry ranks as the greatest virtue. They create intricate murals, paint sprawling murals across cavern walls, and indulge in a wide variety of other artistic disciplines. They esteem stone carving as the greatest of skills.",
-					"Stone giants strive to draw shapes out of raw stone, which they believe reveal meaning inspired by their god, Skoraeus Stonebones. The giants appoint the tribe's best carvers as their leaders, shamans, and prophets. The holy hands of such giants become the hands of the god as they work.",
-					"Graceful Athletes. Despite their great size and musculature, stone giants are lithe and graceful. Skilled rock throwers are granted positions of high rank in the giants' ordning, testing and demonstrating their ability to hurl and catch enormous boulders. Such giants take the front ranks when a tribe has cause to defend its home or attack its enemies. However, even in combat, artistry is key. A stone giant hurling a rock performs not just a feat of brute strength but also one of stunning athleticism and poise.",
-					"Dreamers under Sky. Stone giants view the world outside their underground homes as a realm of dreams where nothing is entirely true or real. They behave in the surface world the way humanoids might behave in their own dreams, making little account for their actions and never fully trusting what they see or hear. A promise made above ground need not be kept. Insults can be made without apology. Killing prey or sentient beings is no cause for guilt in the dreaming world beneath the sky.",
-					"Stone giants lacking in athletic grace or artistic skill dwell at the fringes of their society, serving as the tribe's outlying guardians and far-wandering hunters. When trespassers stray too far into the mountain territory of a stone giant clan, those guardians greet them with hurled rocks and showers of splintered stone. Survivors of such encounters spread tales of stone giant violence, never realizing how little those brutes dwelling in the unreal dreaming world resemble their quiet and artistic kin.",
 					{
 						"type": "entries",
-						"name": "Giants",
+						"name": "Inhabitants of a Stone World",
 						"entries": [
-							"Ancient empires once cast long shadows over a world that quaked beneath the giants' feet. In those lost days, these towering figures were dragon slayers, dreamers, crafters, and kings, but their kind fell from glory long ago. However, even divided among secluded clans scattered throughout the world, the giants maintain the customs and traditions of old.",
-							"Old as Legend. In remote regions of the world, the last remaining plinths, monoliths, and statues of the great giant empires bow their heads in desolate obscurity. Where once those empires sprawled across all lands, now the giants dwell in isolated tribes and clans.",
-							"Giants are almost as old as dragons, which were still young when the giants' heavy feet first shook the foundations of the world. As they spread across new lands, giants and dragons fought bitter generational wars that nearly brought both sides low. No living giant remembers what started the conflict, but myths and tales of their race's glorious dawn are still sung in their steadings and holdfasts, vilifying the primeval wyrms. Giants and dragons continue to harbor grudges against one another, and it is seldom that they will meet or occupy the same area without a fight."
+							"Secluded caves are the homes of the stone giants. Cavern networks are their towns, rocky tunnels their roads, and underground streams their waterways. Isolated mountain ranges are their continents, with the vast spans of land between seen as oceans that the stone giants only rarely cross.",
+							"In their dark, quiet caves, stone giants wordlessly chip away at elaborate carvings, measuring time in the echoing drip of water into cavern pools. In the deepest chambers of a stone giant settlement, far from the chittering of bats or the patrols paced out by the giants' cave bear companions, are holy places where silence and darkness are complete. Stone takes on its most sacred quality in these cavern cathedrals, their buttresses and columns carved with a beauty that shames the legendary stone craft of the dwarves."
 						]
 					},
 					{
 						"type": "entries",
-						"name": "The Ordning",
+						"name": "Carvers and Seers",
 						"entries": [
-							"Each of the main giant races-the cloud, fire, frost, hill, stone, and storm giants-are related by common elements of history, religion, and culture. They view one another as kindred, keeping any inherent animosity over territory and ambition to a minimum.",
-							"Giants belong to a caste structure called the ordning. Based on social class and highly organized, the ordning assigns a social rank to each giant. By understanding its place in the ordning, a giant knows which other giants are inferior or superior to it, since no two giants are equal. Each of the giant races analyzes a different combination of skills or qualities to determine the ordning. Giants make excelling in these qualities the purpose of their lives.",
-							"At the highest level of the ordning, the races of the giants are also ranked according to status. Storm giants are the highest in the ordning, followed by cloud giants, fire giants, frost giants, stone giants, hill giants, and finally giant kin such as fomorians, ettins, and ogres.",
-							"Regardless of a giant's rank among its own race, the chief of a hill giant tribe is inferior to the most common of stone giants. The lowest ranked giant of any type is superior to the highest ranked giant of an inferior type. It isn't considered evil to disrespect or even betray a giant of another type, merely rude."
+							"Among stone giants, artistry ranks as the greatest virtue. They create intricate murals, paint sprawling murals across cavern walls, and indulge in a wide variety of other artistic disciplines. They esteem stone carving as the greatest of skills.",
+							"Stone giants strive to draw shapes out of raw stone, which they believe reveal meaning inspired by their god, Skoraeus Stonebones. The giants appoint the tribe's best carvers as their leaders, shamans, and prophets. The holy hands of such giants become the hands of the god as they work."
 						]
 					},
 					{
 						"type": "entries",
-						"name": "Giant Gods",
+						"name": "Graceful Athletes",
 						"entries": [
-							"When the giants' ancient empires fell, Annam, father of all giants, forsook his children and the world. He swore never to look upon either again until the giants had returned to their glory and reclaimed their birthright as rulers of the world. As a result, giants pray not to Annam but to his divine children, along with a host of hero-deities and godly villains that make up the giants' pantheon.",
-							"Chief among these gods are the children of Annam, whose sons represent each type of giant: Stronmaus for storm giants, Memnor for cloud giants, Skoraeus Stonebones for stone giants, Thrym for frost giants, Surtur for fire giants, and Grolantor for hill giants. Not all giants automatically revere their kind's primary deity, however. Many good cloud giants refuse to worship the deceitful Memnor, and a storm giant dwelling in the icy mountains of the north might pay more homage to Thrym than Stronmaus. Other giants feel a stronger connection to Annam's daughters, who include Hiatea, the huntress and home warden; Iallanis, goddess of love and peace; and Diancastra, an impetuous and arrogant trickster.",
-							"Some giants abandon their own gods and fall prey to demon cults, paying homage to Baphomet or Kostchtchie. To worship them or any other non-giant deity is a great sin against the ordning, and almost certain to make a giant an outcast."
+							"Despite their great size and musculature, stone giants are lithe and graceful. Skilled rock throwers are granted positions of high rank in the giants' ordning, testing and demonstrating their ability to hurl and catch enormous boulders. Such giants take the front ranks when a tribe has cause to defend its home or attack its enemies. However, even in combat, artistry is key. A stone giant hurling a rock performs not just a feat of brute strength but also one of stunning athleticism and poise."
+						]
+					},
+					{
+						"type": "entries",
+						"name": "Dreamers under Sky",
+						"entries": [
+							"Stone giants view the world outside their underground homes as a realm of dreams where nothing is entirely true or real. They behave in the surface world the way humanoids might behave in their own dreams, making little account for their actions and never fully trusting what they see or hear. A promise made above ground need not be kept. Insults can be made without apology. Killing prey or sentient beings is no cause for guilt in the dreaming world beneath the sky.",
+							"Stone giants lacking in athletic grace or artistic skill dwell at the fringes of their society, serving as the tribe's outlying guardians and far-wandering hunters. When trespassers stray too far into the mountain territory of a stone giant clan, those guardians greet them with hurled rocks and showers of splintered stone. Survivors of such encounters spread tales of stone giant violence, never realizing how little those brutes dwelling in the unreal dreaming world resemble their quiet and artistic kin."
 						]
 					}
 				]
+			},
+			"_appendCopy": {
+				"name": "Giant",
+				"source": "MM"
 			}
 		},
 		{
@@ -8090,41 +8215,35 @@
 				"entries": [
 					"Storm giants are contemplative seers that live in places far removed from mortal civilization. Most have pale purple-gray skin and hair, and glittering emerald eyes.",
 					"Some rare storm giants are violet-skinned, with deep violet or blue-black hair and silvery gray or purple eyes. They are benevolent and wise unless angered, in response to which the fury of a storm giant can affect the fate of thousands.",
-					"Distant Prophet-Kings. Storm giants live in isolated refuges so far above the surface of the world or below the sea that they are beyond the reach of most other creatures. Some make their abodes in cloud-top castles so high that flying dragons appear as specks below. Others live atop mountain peaks that pierce the clouds. Some occupy palaces covered with algae and coral at the bottom of the ocean, or grim fortresses in undersea rifts.",
-					"Detached Oracles. Storm giants recall the glory of ancient giant empires forged by the god Annam. They seek to restore what was lost when those empires fell. They don't compete for status in the ordning but live out the centuries of their existence in contemplative seclusion, watching the starry heavens and the ocean's depths for signs, symbols, and omens of Annam's favor.",
-					"Storm giants see the events of the world in a wide perspective. They can foretell the rise and fall of kings and empires, see the beginnings and ends of fortune and disaster, and find the patterns within seemingly unrelated events. By reading omens and prophesying, storm giants learn of vast secrets previously unknown and troves of lore utterly forgotten.",
-					"Kings will rise and fall, wars will be won and lost, and good and evil will wrestle in conflict. Storm giants have watched these events in the manner of mortal gods over many lifetimes, and they know it is pointless to intervene. Even so, a storm giant might willingly disclose certain secrets to benevolent beings that visit its remote domain with specific purpose. Such creatures must speak and act respectfully, however, for a storm giant roused to anger is a force of utter destruction.",
-					"Solitary Lives. Storm giants communicate infrequently with others of their kind. They do so usually to compare signs and omens or engage in a rare courtship. Storm giant parents stay together to raise a child to maturity, then return to the solitary isolation they cherish.",
-					"Some humanoid cultures worship storm giants as they would worship lesser gods, creating myths and stories around the giants' exploits and vast knowledge. A storm giant is governed by the dictates of its conscience, however, and not by any culture's laws or codes of honor. As such, a storm giant that bends its mind toward greed or gains a taste for petty power can easily become a terrible threat.",
 					{
 						"type": "entries",
-						"name": "Giants",
+						"name": "Distant Prophet-Kings",
 						"entries": [
-							"Ancient empires once cast long shadows over a world that quaked beneath the giants' feet. In those lost days, these towering figures were dragon slayers, dreamers, crafters, and kings, but their kind fell from glory long ago. However, even divided among secluded clans scattered throughout the world, the giants maintain the customs and traditions of old.",
-							"Old as Legend. In remote regions of the world, the last remaining plinths, monoliths, and statues of the great giant empires bow their heads in desolate obscurity. Where once those empires sprawled across all lands, now the giants dwell in isolated tribes and clans.",
-							"Giants are almost as old as dragons, which were still young when the giants' heavy feet first shook the foundations of the world. As they spread across new lands, giants and dragons fought bitter generational wars that nearly brought both sides low. No living giant remembers what started the conflict, but myths and tales of their race's glorious dawn are still sung in their steadings and holdfasts, vilifying the primeval wyrms. Giants and dragons continue to harbor grudges against one another, and it is seldom that they will meet or occupy the same area without a fight."
+							"Storm giants live in isolated refuges so far above the surface of the world or below the sea that they are beyond the reach of most other creatures. Some make their abodes in cloud-top castles so high that flying dragons appear as specks below. Others live atop mountain peaks that pierce the clouds. Some occupy palaces covered with algae and coral at the bottom of the ocean, or grim fortresses in undersea rifts."
 						]
 					},
 					{
 						"type": "entries",
-						"name": "The Ordning",
+						"name": "Detached Oracles",
 						"entries": [
-							"Each of the main giant races-the cloud, fire, frost, hill, stone, and storm giants-are related by common elements of history, religion, and culture. They view one another as kindred, keeping any inherent animosity over territory and ambition to a minimum.",
-							"Giants belong to a caste structure called the ordning. Based on social class and highly organized, the ordning assigns a social rank to each giant. By understanding its place in the ordning, a giant knows which other giants are inferior or superior to it, since no two giants are equal. Each of the giant races analyzes a different combination of skills or qualities to determine the ordning. Giants make excelling in these qualities the purpose of their lives.",
-							"At the highest level of the ordning, the races of the giants are also ranked according to status. Storm giants are the highest in the ordning, followed by cloud giants, fire giants, frost giants, stone giants, hill giants, and finally giant kin such as fomorians, ettins, and ogres.",
-							"Regardless of a giant's rank among its own race, the chief of a hill giant tribe is inferior to the most common of stone giants. The lowest ranked giant of any type is superior to the highest ranked giant of an inferior type. It isn't considered evil to disrespect or even betray a giant of another type, merely rude."
+							"Storm giants recall the glory of ancient giant empires forged by the god Annam. They seek to restore what was lost when those empires fell. They don't compete for status in the ordning but live out the centuries of their existence in contemplative seclusion, watching the starry heavens and the ocean's depths for signs, symbols, and omens of Annam's favor.",
+							"Storm giants see the events of the world in a wide perspective. They can foretell the rise and fall of kings and empires, see the beginnings and ends of fortune and disaster, and find the patterns within seemingly unrelated events. By reading omens and prophesying, storm giants learn of vast secrets previously unknown and troves of lore utterly forgotten.",
+							"Kings will rise and fall, wars will be won and lost, and good and evil will wrestle in conflict. Storm giants have watched these events in the manner of mortal gods over many lifetimes, and they know it is pointless to intervene. Even so, a storm giant might willingly disclose certain secrets to benevolent beings that visit its remote domain with specific purpose. Such creatures must speak and act respectfully, however, for a storm giant roused to anger is a force of utter destruction."
 						]
 					},
 					{
 						"type": "entries",
-						"name": "Giant Gods",
+						"name": "Solitary Lives",
 						"entries": [
-							"When the giants' ancient empires fell, Annam, father of all giants, forsook his children and the world. He swore never to look upon either again until the giants had returned to their glory and reclaimed their birthright as rulers of the world. As a result, giants pray not to Annam but to his divine children, along with a host of hero-deities and godly villains that make up the giants' pantheon.",
-							"Chief among these gods are the children of Annam, whose sons represent each type of giant: Stronmaus for storm giants, Memnor for cloud giants, Skoraeus Stonebones for stone giants, Thrym for frost giants, Surtur for fire giants, and Grolantor for hill giants. Not all giants automatically revere their kind's primary deity, however. Many good cloud giants refuse to worship the deceitful Memnor, and a storm giant dwelling in the icy mountains of the north might pay more homage to Thrym than Stronmaus. Other giants feel a stronger connection to Annam's daughters, who include Hiatea, the huntress and home warden; Iallanis, goddess of love and peace; and Diancastra, an impetuous and arrogant trickster.",
-							"Some giants abandon their own gods and fall prey to demon cults, paying homage to Baphomet or Kostchtchie. To worship them or any other non-giant deity is a great sin against the ordning, and almost certain to make a giant an outcast."
+							"Storm giants communicate infrequently with others of their kind. They do so usually to compare signs and omens or engage in a rare courtship. Storm giant parents stay together to raise a child to maturity, then return to the solitary isolation they cherish.",
+							"Some humanoid cultures worship storm giants as they would worship lesser gods, creating myths and stories around the giants' exploits and vast knowledge. A storm giant is governed by the dictates of its conscience, however, and not by any culture's laws or codes of honor. As such, a storm giant that bends its mind toward greed or gains a taste for petty power can easily become a terrible threat."
 						]
 					}
 				]
+			},
+			"_appendCopy": {
+				"name": "Giant",
+				"source": "MM"
 			}
 		},
 		{
@@ -8895,20 +9014,12 @@
 			"entries": {
 				"type": "entries",
 				"entries": [
-					"A water elemental is a cresting wave that rolls across the ground, becoming nearly invisible at it courses through a larger body of water. It engulfs creatures that stand against it, filling their mouths and lungs as easily as it smothers flame.",
-					{
-						"type": "entries",
-						"name": "Elementals",
-						"entries": [
-							"Elementals are incarnations of the elements that make up the universe: air, earth, fire, and water. Though little more than animated energy on their own planes of existence, they can be called on by spellcasters and powerful beings to take shape and perform tasks.",
-							"#bis;#bis;Living Elements. On its home plane, an elemental is a bodiless life force. Its dim consciousness manifests as a physical shape only when focused by the power of magic. A wild spirit of elemental force has no desire except to course through the element of its native plane. Like beasts of the Material Plane, these elemental spirits have no society or culture, and little sense of being.",
-							"Conjured by Magic. Certain spells and magic items can conjure an elemental, summoning it from the Inner Planes to the Material Plane. Elementals instinctively resent being pulled from their native planes and bound into service. A creature that summons an elemental must assert force of will to control it.",
-							"Bound and Shaped. Powerful magic can bind an elemental spirit into a material template that defines a specific use and function. Invisible stalkers are air elementals bound to a specific form, in the same way that water elementals can be shaped into water weirds.",
-							"The strength of the magic and materials that bind an elemental determines how well the elemental functions in a bound form. Golems are elemental spirits bound to physical forms, but weaker materials such as flesh and clay can't bind elemental power sufficiently. Durable materials such as stone and iron require stronger magic, which consequently binds an elemental more securely.",
-							"Elemental Nature. An elemental doesn't require air, food, drink, or sleep."
-						]
-					}
+					"A water elemental is a cresting wave that rolls across the ground, becoming nearly invisible at it courses through a larger body of water. It engulfs creatures that stand against it, filling their mouths and lungs as easily as it smothers flame."
 				]
+			},
+			"_appendCopy": {
+				"name": "Elemental",
+				"source": "MM"
 			}
 		},
 		{


### PR DESCRIPTION
Added giant, elemental, and mephit generic entries so that the specific creatures
references those instead of repeating the same text.
Probably missed some others can be grouped.

Improved Devil data format (I probably used weird solutions - nesting "entries" - trying
to get the "Infernal Hierarchy" header underlined), Driders and maybe others.