### PR TITLE
Adds a check to see if nav class is undefined

### DIFF
--- a/js/classes.js
+++ b/js/classes.js
@@ -791,11 +791,12 @@ function loadsub (sub) {
 					navClass = "n3";
 					break;
 			}
-
-			$(`<div class="nav-item ${navClass}">${displayText}</div>`).on("click", () => {
-				const $it = $(`[data-title-index="${scrollTo}"]`);
-				if ($it.get()[0]) $it.get()[0].scrollIntoView();
-			}).appendTo($nav);
+			if (typeof navClass != 'undefined') {
+				$(`<div class="nav-item ${navClass}">${displayText}</div>`).on("click", () => {
+					const $it = $(`[data-title-index="${scrollTo}"]`);
+					if ($it.get()[0]) $it.get()[0].scrollIntoView();
+				}).appendTo($nav);
+			}
 		}
 
 		if (!CollectionUtil.arrayEq(prevSub, sub)) { // checking array equality is faster than hitting the DOM


### PR DESCRIPTION
The sticky-nav only supports a few excplicit section types, in the case where there's a different section type, it will still go through and the nav class will be undefined.