### PR TITLE
Fixed missing reference to POTA monster

### DIFF
--- a/data/adventure/adventure-pota.json
+++ b/data/adventure/adventure-pota.json
@@ -8251,7 +8251,7 @@
 					"type": "entries",
 					"name": "E22. Display Hall",
 					"entries": [
-						"Two Eternal Flame guardians (see chapter 7) stand guard here.",
+						"Two {@creature Eternal Flame guardian|pota|Eternal Flame guardians} (see chapter 7) stand guard here.",
 						{
 							"type": "inset",
 							"entries": [


### PR DESCRIPTION
Sorry if I'm committing them one by one, but I'm finding them going through the handouts.