### PR TITLE
Fix for slow performance on deleting homebrew sources

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -3368,6 +3368,7 @@ BrewUtil = {
 							const deleteFn = getDeleteFunction(it.category.toLowerCase().replace(/ /g, ""));
 							deleteFn(it.uid, false);
 						});
+						BrewUtil.storage.setItem(HOMEBREW_STORAGE, JSON.stringify(BrewUtil.homebrew));
 						populateList();
 						refreshBrewList();
 						window.location.hash = "";
@@ -3494,6 +3495,7 @@ BrewUtil = {
 					deleteFn(uId, false);
 				});
 			});
+			BrewUtil.storage.setItem(HOMEBREW_STORAGE, JSON.stringify(BrewUtil.homebrew));
 			BrewUtil.removeJsonSource(source);
 			// remove the source from the filters and re-render the filter box
 			if (BrewUtil._sourceFilter) BrewUtil._sourceFilter.removeIfExists(source);
@@ -3507,7 +3509,6 @@ BrewUtil = {
 			const index = getIndex(arrName, uniqueId);
 			if (~index) {
 				BrewUtil.homebrew[arrName].splice(index, 1);
-				BrewUtil.storage.setItem(HOMEBREW_STORAGE, JSON.stringify(BrewUtil.homebrew));
 				if (doRefresh) refreshBrewList();
 				BrewUtil._lists.forEach(l => l.remove("uniqueid", uniqueId));
 				if (doRefresh) History.hashChange();


### PR DESCRIPTION
It looks like the issue was that it reserialises the JSON after it
removes each individual item from the homebrew source. For a large source
this can be pretty intensive. I moved the serialisation to outside the two
loops where this happens and it seems to work a lot faster now.

I don't think there's anywhere else that needs to change but I'm
obviously not that familiar with the code so probably worth reviewing
carefully!