### PR TITLE
bestiary-mft.json, Duergar Warlor, reaction

### DIFF
--- a/data/bestiary/bestiary-mtf.json
+++ b/data/bestiary/bestiary-mtf.json
@@ -6061,7 +6061,7 @@
 				{
 					"name": "Scouring Instruction",
 					"entries": [
-						"When an ally that the duergar can see makes a {@dice d20} roll, the duergar can roll a {@dice 1d6}|{@dice d6} and the ally can add the number rolled to the {@dice d20} roll by taking 3 ({@damage 1d6}) psychic damage. A creature immune to psychic damage can't be affected by Scouring Instruction."
+						"When an ally that the duergar can see makes a {@dice d20} roll, the duergar can roll a {@dice d6} and the ally can add the number rolled to the {@dice d20} roll by taking 3 ({@damage 1d6}) psychic damage. A creature immune to psychic damage can't be affected by Scouring Instruction."
 					]
 				}
 			],


### PR DESCRIPTION
Duergar Warlord had "{@dice 1d6}|{@dice d6}" instead of just "{@dice d6}" in the Scouring Instruction reaction