### PR TITLE
bestiary-oota.json, duergar soulblade, typo

### DIFF
--- a/data/bestiary/bestiary-oota.json
+++ b/data/bestiary/bestiary-oota.json
@@ -1669,7 +1669,7 @@
 				{
 					"name": "Create Soulblade",
 					"entries": [
-						"The duergar creates a visible, shortsword-sized blade of psionic energy. The weapon appears int he duergar's hand and vanishes if it leaves the duergar's grip, or if the duergar dies or is {@condition incapacitated}."
+						"The duergar creates a visible, shortsword-sized blade of psionic energy. The weapon appears in the duergar's hand and vanishes if it leaves the duergar's grip, or if the duergar dies or is {@condition incapacitated}."
 					]
 				},
 				{


### PR DESCRIPTION
**from** _int he duergar's hand_ **to** _in the duergar's hand_

