### PR TITLE
Correct Zarl to Ziraj in Doom Raiders image title

### DIFF
--- a/data/adventure/adventure-wdh.json
+++ b/data/adventure/adventure-wdh.json
@@ -14142,7 +14142,7 @@
 								"type": "internal",
 								"path": "adventure/WDH/The-Doom-Raiders.jpg"
 							},
-							"title": "The Doom Raiders (Left to Right): Davil Starson, Istrid Horn, Tashlyn Yafeera, Skeemo Weirdbottle and Zarl the Hunter"
+							"title": "The Doom Raiders (Left to Right): Davil Starson, Istrid Horn, Tashlyn Yafeera, Skeemo Weirdbottle and Ziraj the Hunter"
 						},
 						"The Doom Raiders were five unscrupulous adventurers who liked to plunder lich lairs (called \"dooms\" by some). They gave up adventuring to join the Black Network and came to Waterdeep three years ago with plans to establish a Zhentarim foothold in the city. In that time, they have forged alliances with various nobles and guilds and run afoul of others, all the while fending off Harper spies.",
 						{


### PR DESCRIPTION
Ziraj the Hunter was mislabeled as Zarl the Hunter