### PR TITLE
Remove isExcluded crash if item has no source defined

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -8167,6 +8167,7 @@ ExcludeUtil = {
 	_excludeCount: 0,
 	isExcluded (name, category, source) {
 		if (!ExcludeUtil._excludes || !ExcludeUtil._excludes.length) return false;
+		if (!source) return false;  // Can't exclude an item if it has no source defined
 		source = source.source || source;
 		const out = !!ExcludeUtil._excludes.find(row => (row.source === "*" || row.source === source) && (row.category === "*" || row.category === category) && (row.name === "*" || row.name === name));
 		if (out) ++ExcludeUtil._excludeCount;


### PR DESCRIPTION
Blood Hunter 2020 was causing class page to crash due to its lack of sources in subclass objects.
This lines ensures that if source is falsey, we short circuit and don't bother checking if it's excluded.