### PR TITLE
Fix Thunderclap target

### DIFF
--- a/data/spells/foundry.json
+++ b/data/spells/foundry.json
@@ -694,9 +694,9 @@
 		{
 			"name": "Thunderclap",
 			"source": "XGE",
-			"targetValue": 5,
+			"targetValue": 15,
 			"targetUnits": "ft",
-			"targetType": "sphere"
+			"targetType": "cube"
 		},
 		{
 			"name": "Tidal Wave",


### PR DESCRIPTION
Thunderclap's RAW is that it affects each creature within range
(5 ft) of the caster. In a grid-based system, this translates
into a 15 ft cube area of effect centered on the caster.