### PR TITLE
Change "+" to space in the search query parameter

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -18,7 +18,7 @@ class SearchPage {
 				if (evt.key !== "Enter") return;
 				$btnSearch.click();
 			})
-			.val(decodeURIComponent(location.search.slice(1)))
+			.val(decodeURIComponent(location.search.slice(1).replace(/\+/g, ' ')))
 
 		const $btnSearch = $(`<button class="btn btn-default"><span class="glyphicon glyphicon-search"></span></button>`)
 			.click(() => {
@@ -111,7 +111,7 @@ class SearchPage {
 			return;
 		}
 
-		Omnisearch.pGetResults(decodeURIComponent(location.search.slice(1)))
+		Omnisearch.pGetResults(decodeURIComponent(location.search.slice(1).replace(/\+/g, ' ')))
 			.then(results => {
 				SearchPage._$wrpResults.empty();
 


### PR DESCRIPTION
The plus sign is reserved for spaces according to the standard URI encoding syntaxx, see https://www.w3.org/Addressing/URL/uri-spec.html.
By doing this, add-ons to browsers and the like can use the OpenSearch syntax.
For example, implementing this would allow me to search directly from the FireFox address bar.