### PR TITLE
Changes titles of "Downtime Activity" variant rules

### DIFF
--- a/data/book/book-dmg.json
+++ b/data/book/book-dmg.json
@@ -12531,15 +12531,15 @@
 									"type": "list",
 									"columns": 3,
 									"items": [
-										"{@variantrule Downtime Activity; Building a Stronghold||Building a Stronghold}",
-										"{@variantrule Downtime Activity; Carousing||Carousing}",
-										"{@variantrule Downtime Activity; Crafting a Magic Item||Crafting a Magic Item}",
-										"{@variantrule Downtime Activity; Gaining Renown||Gaining Renown}",
-										"{@variantrule Downtime Activity; Performing Sacred Rites||Performing Sacred Rites}",
-										"{@variantrule Downtime Activity; Running a Business||Running a Business}",
-										"{@variantrule Downtime Activity; Selling Magic Items||Selling Magic Items}",
-										"{@variantrule Downtime Activity; Sowing Rumors||Sowing Rumors}",
-										"{@variantrule Downtime Activity; Training to Gain Levels||Training to Gain Levels}"
+										"{@variantrule Downtime Activity: Building a Stronghold||Building a Stronghold}",
+										"{@variantrule Downtime Activity: Carousing||Carousing}",
+										"{@variantrule Downtime Activity: Crafting a Magic Item||Crafting a Magic Item}",
+										"{@variantrule Downtime Activity: Gaining Renown||Gaining Renown}",
+										"{@variantrule Downtime Activity: Performing Sacred Rites||Performing Sacred Rites}",
+										"{@variantrule Downtime Activity: Running a Business||Running a Business}",
+										"{@variantrule Downtime Activity: Selling Magic Items||Selling Magic Items}",
+										"{@variantrule Downtime Activity: Sowing Rumors||Sowing Rumors}",
+										"{@variantrule Downtime Activity: Training to Gain Levels||Training to Gain Levels}"
 									]
 								}
 							],

--- a/data/variantrules.json
+++ b/data/variantrules.json
@@ -556,7 +556,7 @@
 			]
 		},
 		{
-			"name": "Downtime Activity; Building a Stronghold",
+			"name": "Downtime Activity: Building a Stronghold",
 			"source": "DMG",
 			"page": 128,
 			"ruleType": "O",
@@ -628,7 +628,7 @@
 			]
 		},
 		{
-			"name": "Downtime Activity; Buying a Magic Item",
+			"name": "Downtime Activity: Buying a Magic Item",
 			"source": "XGE",
 			"page": 126,
 			"ruleType": "VO",
@@ -815,7 +815,7 @@
 			]
 		},
 		{
-			"name": "Downtime Activity; Carousing",
+			"name": "Downtime Activity: Carousing",
 			"source": "DMG",
 			"page": 128,
 			"ruleType": "O",
@@ -867,7 +867,7 @@
 			]
 		},
 		{
-			"name": "Downtime Activity; Carousing",
+			"name": "Downtime Activity: Carousing",
 			"source": "XGE",
 			"page": 127,
 			"ruleType": "VO",
@@ -1090,7 +1090,7 @@
 			]
 		},
 		{
-			"name": "Downtime Activity; Crafting a Magic Item",
+			"name": "Downtime Activity: Crafting a Magic Item",
 			"source": "DMG",
 			"page": 128,
 			"additionalSources": [
@@ -1164,7 +1164,7 @@
 			]
 		},
 		{
-			"name": "Downtime Activity; Crafting an Item",
+			"name": "Downtime Activity: Crafting an Item",
 			"source": "XGE",
 			"page": 128,
 			"ruleType": "VO",
@@ -1397,7 +1397,7 @@
 			]
 		},
 		{
-			"name": "Downtime Activity; Crime",
+			"name": "Downtime Activity: Crime",
 			"source": "XGE",
 			"page": 130,
 			"ruleType": "VO",
@@ -1513,7 +1513,7 @@
 			]
 		},
 		{
-			"name": "Downtime Activity; Gaining Renown",
+			"name": "Downtime Activity: Gaining Renown",
 			"source": "DMG",
 			"page": 129,
 			"ruleType": "O",
@@ -1522,7 +1522,7 @@
 			]
 		},
 		{
-			"name": "Downtime Activity; Gambling",
+			"name": "Downtime Activity: Gambling",
 			"source": "XGE",
 			"page": 130,
 			"ruleType": "VO",
@@ -1625,7 +1625,7 @@
 			]
 		},
 		{
-			"name": "Downtime Activity; Performing Sacred Rites",
+			"name": "Downtime Activity: Performing Sacred Rites",
 			"source": "DMG",
 			"page": 129,
 			"ruleType": "O",
@@ -1636,7 +1636,7 @@
 			]
 		},
 		{
-			"name": "Downtime Activity; Pit Fighting",
+			"name": "Downtime Activity: Pit Fighting",
 			"source": "XGE",
 			"page": 131,
 			"ruleType": "VO",
@@ -1739,7 +1739,7 @@
 			]
 		},
 		{
-			"name": "Downtime Activity; Relaxation",
+			"name": "Downtime Activity: Relaxation",
 			"source": "XGE",
 			"page": 131,
 			"ruleType": "VO",
@@ -1770,7 +1770,7 @@
 			]
 		},
 		{
-			"name": "Downtime Activity; Religious Service",
+			"name": "Downtime Activity: Religious Service",
 			"source": "XGE",
 			"page": 131,
 			"ruleType": "VO",
@@ -1870,7 +1870,7 @@
 			]
 		},
 		{
-			"name": "Downtime Activity; Research",
+			"name": "Downtime Activity: Research",
 			"source": "XGE",
 			"page": 132,
 			"ruleType": "VO",
@@ -1975,7 +1975,7 @@
 			]
 		},
 		{
-			"name": "Downtime Activity; Running a Business",
+			"name": "Downtime Activity: Running a Business",
 			"source": "DMG",
 			"page": 129,
 			"ruleType": "O",
@@ -2028,7 +2028,7 @@
 			]
 		},
 		{
-			"name": "Downtime Activity; Scribing a Spell Scroll",
+			"name": "Downtime Activity: Scribing a Spell Scroll",
 			"source": "XGE",
 			"page": 133,
 			"ruleType": "VO",
@@ -2160,7 +2160,7 @@
 			]
 		},
 		{
-			"name": "Downtime Activity; Selling a Magic Item",
+			"name": "Downtime Activity: Selling a Magic Item",
 			"source": "XGE",
 			"page": 133,
 			"ruleType": "VO",
@@ -2295,7 +2295,7 @@
 			]
 		},
 		{
-			"name": "Downtime Activity; Selling Magic Items",
+			"name": "Downtime Activity: Selling Magic Items",
 			"source": "DMG",
 			"page": 129,
 			"ruleType": "O",
@@ -2388,7 +2388,7 @@
 			]
 		},
 		{
-			"name": "Downtime Activity; Sowing Rumors",
+			"name": "Downtime Activity: Sowing Rumors",
 			"source": "DMG",
 			"page": 131,
 			"ruleType": "O",
@@ -2426,7 +2426,7 @@
 			]
 		},
 		{
-			"name": "Downtime Activity; Training",
+			"name": "Downtime Activity: Training",
 			"source": "XGE",
 			"page": 134,
 			"ruleType": "VO",
@@ -2491,7 +2491,7 @@
 			]
 		},
 		{
-			"name": "Downtime Activity; Training to Gain Levels",
+			"name": "Downtime Activity: Training to Gain Levels",
 			"source": "DMG",
 			"page": 131,
 			"ruleType": "V",
@@ -2537,7 +2537,7 @@
 			]
 		},
 		{
-			"name": "Downtime Activity; Work",
+			"name": "Downtime Activity: Work",
 			"source": "XGE",
 			"page": 134,
 			"ruleType": "VO",
@@ -2819,19 +2819,19 @@
 						{
 							"type": "list",
 							"items": [
-								"{@variantrule Downtime Activity; Buying a Magic Item|XGE}",
-								"{@variantrule Downtime Activity; Carousing|XGE}",
-								"{@variantrule Downtime Activity; Crafting an Item|XGE}",
-								"{@variantrule Downtime Activity; Crime|XGE}",
-								"{@variantrule Downtime Activity; Gambling|XGE}",
-								"{@variantrule Downtime Activity; Pit Fighting|XGE}",
-								"{@variantrule Downtime Activity; Relaxation|XGE}",
-								"{@variantrule Downtime Activity; Religious Service|XGE}",
-								"{@variantrule Downtime Activity; Research|XGE}",
-								"{@variantrule Downtime Activity; Scribing a Spell Scroll|XGE}",
-								"{@variantrule Downtime Activity; Selling a Magic Item|XGE}",
-								"{@variantrule Downtime Activity; Training|XGE}",
-								"{@variantrule Downtime Activity; Work|XGE}"
+								"{@variantrule Downtime Activity: Buying a Magic Item|XGE}",
+								"{@variantrule Downtime Activity: Carousing|XGE}",
+								"{@variantrule Downtime Activity: Crafting an Item|XGE}",
+								"{@variantrule Downtime Activity: Crime|XGE}",
+								"{@variantrule Downtime Activity: Gambling|XGE}",
+								"{@variantrule Downtime Activity: Pit Fighting|XGE}",
+								"{@variantrule Downtime Activity: Relaxation|XGE}",
+								"{@variantrule Downtime Activity: Religious Service|XGE}",
+								"{@variantrule Downtime Activity: Research|XGE}",
+								"{@variantrule Downtime Activity: Scribing a Spell Scroll|XGE}",
+								"{@variantrule Downtime Activity: Selling a Magic Item|XGE}",
+								"{@variantrule Downtime Activity: Training|XGE}",
+								"{@variantrule Downtime Activity: Work|XGE}"
 							]
 						}
 					]


### PR DESCRIPTION
Changes the semi-colon to a colon in the variant rule names and updates references to them. Yes, it's that nit-picky, but it was bothering me as I frequently reference those rules in my games.