### PR TITLE
homebrew manager more safely retrieves the name/author

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -3697,7 +3697,7 @@ BrewUtil = {
 					dataList.push({
 						download_url: DataUtil.brew.getFileUrl(path, urlRoot),
 						path,
-						name: path.split("/").slice(1).join("/"),
+						name: path.slice(path.indexOf("/")+1),
 						_cat: BrewUtil.dirToProp(dir),
 					})
 				})


### PR DESCRIPTION
Previously, if the json path lacked a folder, the name/author would be blank.
Now the nested folder path is optional

This will allow repos that do not use nested folders to display their name/authors in the brewmanager

This is for [issue-320](https://github.com/TheGiddyLimit/TheGiddyLimit.github.io/issues/320)