### PR TITLE
Render time.number only if truthy

### DIFF
--- a/js/filter-spells.js
+++ b/js/filter-spells.js
@@ -192,7 +192,7 @@ class PageFilterSpells extends PageFilter {
 	static getTblTimeStr (time) {
 		return (time.number === 1 && Parser.SP_TIME_SINGLETONS.includes(time.unit))
 			? `${time.unit.uppercaseFirst()}${time.unit === Parser.SP_TM_B_ACTION ? " acn." : ""}`
-			: `${time.number} ${time.unit === Parser.SP_TM_B_ACTION ? "Bonus acn." : time.unit.uppercaseFirst()}${time.number > 1 ? "s" : ""}`;
+			: `${time.number ? `${time.number} ` : ""}${time.unit === Parser.SP_TM_B_ACTION ? "Bonus acn." : time.unit.uppercaseFirst()}${time.number > 1 ? "s" : ""}`;
 	}
 
 	static getClassFilterItem (c) {

--- a/js/parser.js
+++ b/js/parser.js
@@ -850,7 +850,7 @@ Parser.spTimeListToFull = function (times, isStripTags) {
 };
 
 Parser.getTimeToFull = function (time) {
-	return `${time.number} ${time.unit === "bonus" ? "bonus action" : time.unit}${time.number > 1 ? "s" : ""}`;
+	return `${time.number ? `${time.number} ` : ""}${time.unit === "bonus" ? "bonus action" : time.unit}${time.number > 1 ? "s" : ""}`;
 };
 
 RNG_SPECIAL = "special";


### PR DESCRIPTION
According to the [schema](https://github.com/TheGiddyLimit/TheGiddyLimit.github.io/blob/master/test/schema/spells/spell.json#L451-L453), the only required property in `time` for a spell is `unit`. However, in both [filter-spell.js](https://github.com/TheGiddyLimit/TheGiddyLimit.github.io/blob/414a1f1a67de9d3f226a60bb374b097ad9a4e8a8/js/filter-spells.js#L195) and [parser.js](https://github.com/TheGiddyLimit/TheGiddyLimit.github.io/blob/e47096c3e098a5855e4f559265e18318fa32cad1/js/parser.js#L853), `number` is always used.
A JSON like this:
```JSON
"time": [
    {
        "unit": "Special"
    }
],
```
renders like so:

![image](https://user-images.githubusercontent.com/22564520/100436731-aa486c00-3097-11eb-87bc-62ad7a78ce7c.png)


This commit makes it so that `number` (and the space after it) is only rendered if it has a truthy value.