### PR TITLE
Removed duplicate DC from the bagman

### DIFF
--- a/data/bestiary/bestiary-vrgr.json
+++ b/data/bestiary/bestiary-vrgr.json
@@ -3461,7 +3461,7 @@
 								{
 									"name": "Alien Mind",
 									"entries": [
-										"If a creature tries to read the Bagman's thoughts, that creature must succeed on a DC {@dc 8} Intelligence saving throw or be {@condition stunned} for 1 minute. The {@condition stunned} creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+										"If a creature tries to read the Bagman's thoughts, that creature must succeed on a {@dc 8} Intelligence saving throw or be {@condition stunned} for 1 minute. The {@condition stunned} creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 									]
 								}
 							]


### PR DESCRIPTION
The `DC` string is already included in the @dc template.