### PR TITLE
Include languages with script fonts under "Has Font" filter

### DIFF
--- a/js/filter-languages.js
+++ b/js/filter-languages.js
@@ -11,7 +11,8 @@ class PageFilterLanguages extends PageFilter {
 	}
 
 	static mutateForFilters (it) {
-		it._fMisc = it.fonts ? ["Has Fonts"] : [];
+		it._fMisc = []
+		if (it.fonts || it._fonts) it._fMisc.push("Has Fonts");
 		if (it.srd) it._fMisc.push("SRD");
 		if (it.hasFluff) it._fMisc.push("Has Info");
 		if (it.hasFluffImages) it._fMisc.push("Has Images");


### PR DESCRIPTION
It seemed strange that languages with fonts from their script didn't show up under the "Has Fonts" filter.

A language's fonts are accumulated for display from [the `fonts` and `_fonts` attributes in `js/languages.js`](https://github.com/TheGiddyLimit/TheGiddyLimit.github.io/blob/af5102beeb285be5050ae8d9aaba0ed0b9a1a69f/js/languages.js#L132); this PR applies the same pattern to the "Has Fonts" filter.