### PR TITLE
Text Converter Tweaks (Mainly Items) + Fixes

### DIFF
--- a/js/converter-item.js
+++ b/js/converter-item.js
@@ -310,6 +310,15 @@ class ItemParser extends BaseParser {
 									genericTypes.push("melee"); break;
 								case "ranged": case "ranged weapon":
 									genericTypes.push("ranged"); break;
+								case "piercing": case "piercing weapon":
+									genericTypes.push("piercing"); break;
+								case "slashing": case "slashing weapon":
+								case "edged": case "edged weapon":
+								case "bladed": case "bladed weapon":
+									genericTypes.push("slashing"); break;
+								case "bludgeoning": case "bludgeoning weapon":
+								case "blunt": case "blunt weapon":
+									genericTypes.push("bludgeoning"); break;
 								case "sword": genericTypes.push("sword"); break;
 								case "axe": genericTypes.push("axe"); break;
 								case "bow": genericTypes.push("bow"); break;
@@ -465,6 +474,9 @@ class ItemParser extends BaseParser {
 				switch (genericType) {
 					case "weapon": stats.requires.push({"weapon": true}); break;
 					case "melee": stats.requires.push({"type": "M"}); break;
+					case "piercing": stats.requires.push({"dmgType": "P"}); break;
+					case "slashing": stats.requires.push({"dmgType": "S"}); break;
+					case "bludgeoning": stats.requires.push({"dmgType": "B"}); break;
 					case "ranged": rstats.equires.push({"type": "R"}); break;
 					case "sword": stats.requires.push({"sword": true}); break;
 					case "axe": stats.requires.push({"axe": true}); break;

--- a/js/converter-item.js
+++ b/js/converter-item.js
@@ -25,6 +25,8 @@ class ItemParser extends BaseParser {
 
 	static _getBaseItem (itemName, category) {
 		let baseItem = ItemParser.getItem(itemName);
+		if (!baseItem) baseItem = ItemParser.getItem(itemName.replace(/s$/i, ""))
+		if (!baseItem) baseItem = ItemParser.getItem(itemName.replace(/es$/i, ""))
 		if (!baseItem && category.toLowerCase() === "armor") {
 			baseItem = ItemParser.getItem(`${itemName} armor`); // "armor (plate)" -> "plate armor"
 		}
@@ -412,8 +414,7 @@ class ItemParser extends BaseParser {
 					if (exceptSep.toLowerCase() !== "without") {
 						const exceptions = except.split(variantListPattern).map(s => s.trim());
 						exceptions.forEach(exceptionName => {
-							let item = ItemParser.getItem(exceptionName);
-							if (!item) item = ItemParser.getItem(`${exceptionName} armor`); // "armor (plate)" -> "plate armor"
+							let item = this._getBaseItem(exceptionName, category);
 							if (!item) throw new Error(`Could not find exception item "${exceptionName}"`);
 							genericVariantExceptions.push(item.name); // correct capitalization
 						});

--- a/js/converter-item.js
+++ b/js/converter-item.js
@@ -189,7 +189,6 @@ class ItemParser extends BaseParser {
 		let genericTypes = [];
 		let genericVariantBases = []; // in case it's a variant of a specific list of items
 		let genericVariantExceptions = [];
-		// let genericVariantProperties = [];
 		let genericVariantExceptProperties = [];
 
 		for (let i = 0; i < parts.length; ++i) {
@@ -290,6 +289,19 @@ class ItemParser extends BaseParser {
 						;
 					
 					baseItems.forEach((itemName) => {
+						const propertyMatch = /(.+?)\s*with(?:\s+the)?\s*(.*?)\s+property/i.exec(itemName);
+						let properties = null;
+						if (propertyMatch) {
+							itemName = propertyMatch[1]; // remove the properties from the item name
+							properties = [];
+							// for each property
+							propertyMatch[2].split(variantListPattern).map(s => s.trim()).forEach(property => {
+								const tag = ItemParser._PROPERTY_TO_TAG[property];
+								if (!tag) throw new Error(`Unknown property "${property}"`);
+								properties.push(tag);
+							});
+						}
+
 						let found = false;
 						if (categoryL === "weapon" || categoryL === "staff") {
 							found = true;
@@ -315,11 +327,31 @@ class ItemParser extends BaseParser {
 							}		
 						}
 
+						// if added generic type, set properties
+						// currently every listed generic type has its own properties
+						// (like 'sword or bow with the light property' will only add the
+						// requirement to bows), might change it if it makes more sense
+						// for them to apply globally
+						if (found && properties) {
+							const addedGenericType = genericTypes.pop(genericTypes);
+							genericTypes.push({
+								"type": addedGenericType,
+								"properties": properties,
+							})
+						} 
+
+						// otherwise, check for specific base generic items
 						if (!found) {
 							let item = this._getBaseItem(itemName, category);
-							if (!item) throw new Error(`Could not find generic base item "${itemName}"`);
-							genericVariantBases.push(item);
+							if (item) {
+								if (properties) throw new Error(`Properties not supported for specific base items (item: ${itemName})`)
+
+								found = true;
+								genericVariantBases.push(item);
+							} 
 						}
+						if (!found)
+							throw new Error(`Could not find generic base item "${itemName}"`);
 						handled = true;
 					});
 					if (!handled) {
@@ -368,7 +400,6 @@ class ItemParser extends BaseParser {
 		if (genericTypes.length != 0) stats.__genericTypes = genericTypes;
 		if (genericVariantBases.length != 0) stats.__genericVariantBases = genericVariantBases;
 		if (genericVariantExceptions.length != 0) stats.__genericVariantExceptions = genericVariantExceptions;
-		// if (genericVariantProperties.length != 0) stats.__genericVariantProperties = genericVariantProperties;
 		if (genericVariantExceptProperties.length != 0) stats.__genericVariantExceptProperties = genericVariantExceptProperties;
 	}
 
@@ -394,17 +425,15 @@ class ItemParser extends BaseParser {
 	}
 
 	static _setCleanTaglineInfo_handleGenericType (stats, options) {
-		if (!(stats.__genericTypes || stats.__genericVariantBases || stats.__genericVariantProperties)) return;
+		if (!(stats.__genericTypes || stats.__genericVariantBases)) return;
 
 		const genericTypes = stats.__genericTypes;
 		const genericVariantBases = stats.__genericVariantBases;
 		const genericVariantExceptions = stats.__genericVariantExceptions;
-		// const genericVariantProperties = stats.__genericVariantProperties;
 		const genericVariantExceptProperties = stats.__genericVariantExceptProperties;
 		delete stats.__genericTypes;
 		delete stats.__genericVariantBases;
 		delete stats.__genericVariantExceptions;
-		// delete stats.__genericVariantProperties;
 		delete stats.__genericVariantExceptProperties;
 
 		let prefixSuffixName = stats.name;
@@ -427,6 +456,12 @@ class ItemParser extends BaseParser {
 		stats.requires = [];
 		if (genericTypes) {
 			genericTypes.forEach(genericType => {
+				let properties = null;
+				if (genericType.properties) {
+					properties = genericType.properties;
+					genericType = genericType.type;
+				}
+
 				switch (genericType) {
 					case "weapon": stats.requires.push({"weapon": true}); break;
 					case "melee": stats.requires.push({"type": "M"}); break;
@@ -441,6 +476,12 @@ class ItemParser extends BaseParser {
 					case "light armor": stats.requires.push({"type": "LA"}); break;
 					default: throw new Error(`Unhandled generic type "${genericType}"`);
 				}
+
+				if (properties) {
+					stats.requires[stats.requires.length-1].property = {
+						"includes": properties,
+					}
+				}
 			});
 		}
 		if (genericVariantBases) {
@@ -450,7 +491,6 @@ class ItemParser extends BaseParser {
 				});
 			});
 		}
-
 		if (genericVariantExceptions || genericVariantExceptProperties) {
 			stats.excludes = {};
 		}

--- a/js/converter-item.js
+++ b/js/converter-item.js
@@ -172,7 +172,10 @@ class ItemParser extends BaseParser {
 				case "artifact": stats.rarity = rarity; return true;
 				case "rarity varies": {
 					stats.rarity = "varies";
-					stats.__prop = "itemGroup";
+					// Do not set itemGroup for now, as it would need a way
+					// to set "items" to properly work and not make the item list
+					// error out
+					// stats.__prop = "itemGroup";
 					return true;
 				}
 				case "unknown rarity": {

--- a/js/converter-item.js
+++ b/js/converter-item.js
@@ -116,17 +116,25 @@ class ItemParser extends BaseParser {
 
 	static _doItemPostProcess_addTags (stats, options) {
 		const manName = stats.name ? `(${stats.name}) ` : "";
-		SpellTag.tryRun(stats);
-		ChargeTag.tryRun(stats);
-		RechargeTypeTag.tryRun(stats, {cbMan: () => options.cbWarning(`${manName}Recharge type requires manual conversion`)});
-		BonusTag.tryRun(stats);
-		ItemMiscTag.tryRun(stats);
-		ItemSpellcastingFocusTag.tryRun(stats);
-		DamageResistanceTag.tryRun(stats);
-		DamageImmunityTag.tryRun(stats);
-		DamageVulnerabilityTag.tryRun(stats);
-		ConditionImmunityTag.tryRun(stats);
-		ReqAttuneTagTag.tryRun(stats);
+		try {
+			SpellTag.tryRun(stats);
+			ChargeTag.tryRun(stats);
+			RechargeTypeTag.tryRun(stats, {cbMan: () => options.cbWarning(`${manName}Recharge type requires manual conversion`)});
+			BonusTag.tryRun(stats);
+			ItemMiscTag.tryRun(stats);
+			ItemSpellcastingFocusTag.tryRun(stats);
+			DamageResistanceTag.tryRun(stats);
+			DamageImmunityTag.tryRun(stats);
+			DamageVulnerabilityTag.tryRun(stats);
+			ConditionImmunityTag.tryRun(stats);
+			ReqAttuneTagTag.tryRun(stats);
+		} catch (e) {
+			JqueryUtil.doToast({
+				content: `Error in tags for ${manName}!`,
+				type: "danger",
+			});
+			setTimeout(() => { throw e });
+		}
 
 		// TODO
 		//  - tag damage type?
@@ -238,9 +246,6 @@ class ItemParser extends BaseParser {
 			if (partLower === "weapon" || partLower === "weapon (any)") {
 				genericType = "weapon";
 				continue;
-			} else if (partLower === "weapon (any sword)") {
-				genericType = "sword";
-				continue;
 			} else if (partLower === "armor" || partLower === "armor (any)") {
 				genericType = "armor";
 				continue;
@@ -272,15 +277,36 @@ class ItemParser extends BaseParser {
 				baseItem = ItemParser.getItem(mBaseWeapon[2]);
 				if (!baseItem) {
 					// check if the items are a list
+					let handled = false;
 					let baseItems = mBaseWeapon[2]
 						.replace(/(a|an|any)\s+/, "")
 						.split(variantListPattern)
 						;
-					let handled = false;
 					baseItems.forEach((itemName) => {
-						let item = ItemParser.getItem(itemName);
-						if (!item) throw new Error(`Could not find base item "${itemName}"`);
-						genericVariantBases.push(item);
+						let found = true;
+						switch (itemName) {
+							case "melee": case "melee weapon":
+								genericType = "melee"; break;
+							case "ranged": case "ranged weapon":
+								genericType = "ranged"; break;
+							case "sword": genericType = "sword"; break;
+							case "axe": genericType = "axe"; break;
+							case "bow": genericType = "bow"; break;
+							case "crossbow":
+								if (genericType === "bow") {
+									genericType = "bow or crossbow";
+								} else {
+									genericType = "crossbow"
+								}
+								break;
+							default: found = false;
+						}
+
+						if (!found) {
+							let item = ItemParser.getItem(itemName);
+							if (!item) throw new Error(`Could not find base item "${itemName}"`);
+							genericVariantBases.push(item);
+						}
 						handled = true;
 					});
 					if (!handled) {
@@ -319,6 +345,7 @@ class ItemParser extends BaseParser {
 							;
 						baseItems.forEach((itemName) => {
 							let item = ItemParser.getItem(itemName);
+							if (!item) item = ItemParser.getItem(`${itemName} armor`); // "armor (plate)" -> "plate armor"
 							if (!item) throw new Error(`Could not find base item "${itemName}"`);
 							genericVariantBases.push(item);
 							handled = true;
@@ -394,7 +421,13 @@ class ItemParser extends BaseParser {
 		if (genericType) {
 			switch (genericType) {
 				case "weapon": stats.requires = [{"weapon": true}]; break;
+				case "melee": throw new Error("Unimplemented!");
+				case "ranged": throw new Error("Unimplemented!");
 				case "sword": stats.requires = [{"sword": true}]; break;
+				case "axe": stats.requires = [{"axe": true}]; break;
+				case "bow": stats.requires = [{"bow": true}]; break;
+				case "crossbow": stats.requires = [{"crossbow": true}]; break;
+				case "bow or crossbow": stats.requires = [{"bow": true}, {"crossbow": true}]; break;
 				case "armor": stats.requires = [{"armor": true}]; break;
 				case "heavy armor": stats.requires = [{"type": "HA"}]; break;
 				case "medium armor": stats.requires = [{"type": "MA"}]; break;
@@ -456,6 +489,7 @@ ItemParser._ALL_CLASSES = null;
 ItemParser._MAPPED_ITEM_NAMES = {
 	"studded leather": "studded leather armor",
 	"leather": "leather armor",
+	"bolt": "crossbow bolt",
 };
 
 if (typeof module !== "undefined") {

--- a/js/converter-item.js
+++ b/js/converter-item.js
@@ -124,21 +124,42 @@ class ItemParser extends BaseParser {
 
 	static _doItemPostProcess_addTags (stats, options) {
 		const manName = stats.name ? `(${stats.name}) ` : "";
+		let step = "start";
 		try {
-			SpellTag.tryRun(stats);
-			ChargeTag.tryRun(stats);
+			const defaultOptions = name => { return {
+				// For debugging if some options were needed
+				cbMan: str => {
+					if (options.verboseWarnings) {
+						options.cbWarning(`${manName}${name}: ${str}`);
+					}
+				}
+			} };
+
+			SpellTag.tryRun(stats, defaultOptions("SpellTag"));
+			step = "spell";
+			ChargeTag.tryRun(stats, defaultOptions("ChargeTag"));
+			step = "charge";
 			RechargeTypeTag.tryRun(stats, {cbMan: () => options.cbWarning(`${manName}Recharge type requires manual conversion`)});
-			BonusTag.tryRun(stats);
-			ItemMiscTag.tryRun(stats);
-			ItemSpellcastingFocusTag.tryRun(stats);
-			DamageResistanceTag.tryRun(stats);
-			DamageImmunityTag.tryRun(stats);
-			DamageVulnerabilityTag.tryRun(stats);
-			ConditionImmunityTag.tryRun(stats);
-			ReqAttuneTagTag.tryRun(stats);
+			step = "recharge";
+			BonusTag.tryRun(stats, defaultOptions("BonusTag"));
+			step = "bonus";
+			ItemMiscTag.tryRun(stats, defaultOptions("ItemMiscTag"));
+			step = "misc";
+			ItemSpellcastingFocusTag.tryRun(stats, defaultOptions("ItemSpellcastingFocusTag"));
+			step = "spellcastingFocus";
+			DamageResistanceTag.tryRun(stats, defaultOptions("DamageResistanceTag"));
+			step = "damageResistance";
+			DamageImmunityTag.tryRun(stats, defaultOptions("DamageImmunityTag"));
+			step = "damageImmunity";
+			DamageVulnerabilityTag.tryRun(stats, defaultOptions("DamageVulnerabilityTag"));
+			step = "damageVulnerability";
+			ConditionImmunityTag.tryRun(stats, defaultOptions("ConditionImmunityTag"));
+			step = "conditionImmunity";
+			ReqAttuneTagTag.tryRun(stats, defaultOptions("ReqAttuneTagTag"));
+			step = "reqAttuneTag";
 		} catch (e) {
 			JqueryUtil.doToast({
-				content: `Error in tags for ${manName}!`,
+				content: `Error in tags for ${manName}, step reached: ${step}!`,
 				type: "danger",
 			});
 			setTimeout(() => { throw e });

--- a/js/converter-item.js
+++ b/js/converter-item.js
@@ -90,7 +90,11 @@ class ItemParser extends BaseParser {
 		this._doItemPostProcess(item, options);
 		this._setCleanTaglineInfo_handleGenericType(item, options);
 		this._doVariantPostProcess(item, options);
-		return PropOrder.getOrdered(item, item.__prop || "item");
+
+		const prop = item.__prop
+		delete item.__prop
+
+		return PropOrder.getOrdered(item, prop || "item");
 	}
 
 	// SHARED UTILITY FUNCTIONS ////////////////////////////////////////////////////////////////////////////////////////

--- a/js/converter-item.js
+++ b/js/converter-item.js
@@ -136,7 +136,10 @@ class ItemParser extends BaseParser {
 
 	// SHARED PARSING FUNCTIONS ////////////////////////////////////////////////////////////////////////////////////////
 	static _setCleanTaglineInfo (stats, curLine, options) {
-		const parts = curLine.split(",").map(it => it.trim()).filter(Boolean);
+		// split on first comma not inside parentheses
+		// \s*(?![^()]*\)) : not inside parentheses
+		// (.*) : only first
+		const parts = curLine.split(/,\s*(?![^()]*\))(.*)/s).map(it => it.trim()).filter(Boolean);
 
 		const handlePartRarity = (rarity) => {
 			rarity = rarity.trim().toLowerCase();

--- a/js/converter-item.js
+++ b/js/converter-item.js
@@ -390,8 +390,6 @@ class ItemParser extends BaseParser {
 						if (!found) {
 							let item = this._getBaseItem(itemName, category);
 							if (item) {
-								if (properties) throw new Error(`Properties not supported for specific base items (item: ${itemName})`)
-
 								found = true;
 								genericVariantBases.push(item);
 							} 

--- a/js/converter-item.js
+++ b/js/converter-item.js
@@ -394,6 +394,9 @@ class ItemParser extends BaseParser {
 								genericVariantBases.push(item);
 							} 
 						}
+						if (!found && (/\s*/.test(itemName) || itemName === categoryL) )
+							// any item of the category, will use property matches too
+							found = true;
 						if (!found)
 							throw new Error(`Could not find generic base item "${itemName}"`);
 						handled = true;
@@ -404,7 +407,7 @@ class ItemParser extends BaseParser {
 				}
 
 				// handle exceptions (but not <item>, except <item>, etc.)
-				if (exceptSep && (genericTypes.length > 0 || genericVariantBases.length > 0)) {
+				if (exceptSep) {
 					// item exceptions
 					if (exceptSep.toLowerCase() !== "without") {
 						const exceptions = except.split(variantListPattern).map(s => s.trim());
@@ -470,7 +473,14 @@ class ItemParser extends BaseParser {
 	}
 
 	static _setCleanTaglineInfo_handleGenericType (stats, options) {
-		if (!(stats.__genericTypes || stats.__genericVariantBases)) return;
+		if (!(
+			stats.__genericTypes 
+			|| stats.__genericVariantBases 
+			|| stats.__genericVariantExceptions 
+			|| stats.__genericVariantRequiresProperties 
+			|| stats.__genericVariantExceptProperties 
+		))
+			return;
 
 		const genericTypes = stats.__genericTypes;
 		const genericVariantBases = stats.__genericVariantBases;

--- a/js/converter.js
+++ b/js/converter.js
@@ -774,9 +774,7 @@ class ConverterUi extends BaseComponent {
 			const output = this._outText;
 			if (output && output.trim()) {
 				try {
-					const prop = this.activeConverter.prop;
-					const out = {[prop]: JSON.parse(`[${output}]`)};
-					DataUtil.userDownload(`converter-output`, out);
+					DataUtil.userDownload(`converter-output`, JSON.parse(output));
 				} catch (e) {
 					JqueryUtil.doToast({
 						content: `Current output was not valid JSON. Downloading as <span class="code">.txt</span> instead.`,

--- a/js/converter.js
+++ b/js/converter.js
@@ -492,7 +492,18 @@ Once the Wreath of the Prism reaches an awakened state, it gains the following b
 Exalted
 Once the Wreath of the Prism reaches an exalted state, it gains the following benefits:
 • You can affect creatures of challenge rating 15 or lower with the wreath.
-• The save DC of the wreath’s spell increases to 17.`;
+• The save DC of the wreath’s spell increases to 17.
+===
+Weapon of Conjuring
+Weapon (any sword or piercing weapon with the light property), Very Rare (requires attunement)
+This weapon conjures a random demon on a critical hit. 
+It is also made up for the purpose of a variant example as there was no magic item I could find with both specific variant requirements (like this with the light property) and a table.
+Other options are "without the x [or y] property", "Armor (heavy but not x <plate, etc.>)", "Weapon (longsword or shortsword)", etc.
+| d4 | Spawned demon | Is cool? |
+| --- | ------- | --: |
+| 1 | barlgura | 1 |
+| 2 | shadow demon | 2 |
+| 3-4 | chasme | 3 |`;
 // endregion
 
 class FeatConverter extends BaseConverter {

--- a/js/converter.js
+++ b/js/converter.js
@@ -63,6 +63,7 @@ class BaseConverter extends BaseComponent {
 		this._renderSidebarConverterOptionsPart(parent, $wrpSidebar);
 		this._renderSidebarPagePart(parent, $wrpSidebar);
 		this._renderSidebarSourcePart(parent, $wrpSidebar);
+		this._renderSidebarDebugPart(parent, $wrpSidebar);
 	}
 
 	_renderSidebar () { throw new Error("Unimplemented!"); }
@@ -205,6 +206,29 @@ class BaseConverter extends BaseComponent {
 
 		ConverterUiUtil.renderSideMenuDivider($wrpSidebar);
 	}
+	
+	_renderSidebarDebugPart (parent, $wrpSidebar) {
+		const $cbRenderTextEachTime = ComponentUiUtil.$getCbBool(this._ui, "renderTextEachTime");
+		$$`<div class="sidemenu__row split-v-center">
+			<label class="sidemenu__row__label sidemenu__row__label--cb-label" title="Should the text in the output be rendered for every converted entry? Slower, but in case an error happens will show the output up to that point"><span>Render Text Every Entry</span>
+			${$cbRenderTextEachTime}
+		</label></div>`.appendTo($wrpSidebar);
+
+		const $cbPrintWarningsToConsole = ComponentUiUtil.$getCbBool(this._ui, "printWarningsToConsole");
+		$$`<div class="sidemenu__row split-v-center">
+			<label class="sidemenu__row__label sidemenu__row__label--cb-label" title="Should converter warnings be printed to console too, instead of only below the output box?"><span>Warnings To Console</span>
+			${$cbPrintWarningsToConsole}
+		</label></div>`.appendTo($wrpSidebar);
+
+		const $cbVerboseWarnings = ComponentUiUtil.$getCbBool(this._ui, "verboseWarnings");
+		$$`<div class="sidemenu__row split-v-center">
+			<label class="sidemenu__row__label sidemenu__row__label--cb-label" title="Should warnings be printed for every part of the text that is possibly a tag but isn't recognized? (For example, damage resistances)"><span>Verbose Warnings</span>
+			${$cbVerboseWarnings}
+		</label></div>`.appendTo($wrpSidebar);
+
+		ConverterUiUtil.renderSideMenuDivider($wrpSidebar);
+	}
+
 	// endregion
 }
 
@@ -806,7 +830,9 @@ class ConverterUi extends BaseComponent {
 				const splitStack = x.stack.split("\n");
 				const atPos = splitStack.length > 1 ? splitStack[1].trim() : "(Unknown location)";
 				const message = `[Error] ${x.message} ${atPos}`;
-				$(`#lastError`).show().html(message);
+				const rtetNotif = (this._state.renderTextEachTime) ? "" : 
+					" (Render Text Every Entry checkbox is off; you can try turning it on to see where the error happened)";
+				$(`#lastError`).show().html(message + rtetNotif);
 				this._editorOut.resize();
 				setTimeout(() => { throw x });
 			}
@@ -951,7 +977,7 @@ ConverterUi._DEFAULT_STATE = {
 	converter: "Creature",
 	sourceJson: "",
 	inputSeparator: "===",
-	renderTextEachTime: true,
+	renderTextEachTime: false,
 	printWarningsToConsole: true,
 	verboseWarnings: false,
 };

--- a/js/converter.js
+++ b/js/converter.js
@@ -502,7 +502,7 @@ Other options are "without the x [or y] property", "Armor (heavy but not x <plat
 | d4 | Spawned demon | Is cool? |
 | --- | ------- | --: |
 | 1 | barlgura | 1 |
-| 2 | shadow demon | 2 |
+| 2 | 1d4 shadow demon | 2 |
 | 3-4 | chasme | 3 |`;
 // endregion
 

--- a/js/converter.js
+++ b/js/converter.js
@@ -494,16 +494,21 @@ Once the Wreath of the Prism reaches an exalted state, it gains the following be
 • You can affect creatures of challenge rating 15 or lower with the wreath.
 • The save DC of the wreath’s spell increases to 17.
 ===
-Weapon of Conjuring
-Weapon (any sword or piercing weapon with the light property), Very Rare (requires attunement)
+Weapon of Generic Variant Conjuring
+Weapon (any sword or piercing melee weapon with the light property), Very Rare (requires attunement)
 This weapon conjures a random demon on a critical hit. 
 It is also made up for the purpose of a variant example as there was no magic item I could find with both specific variant requirements (like this with the light property) and a table.
-Other options are "without the x [or y] property", "Armor (heavy but not x <plate, etc.>)", "Weapon (longsword or shortsword)", etc.
 | d4 | Spawned demon | Is cool? |
 | --- | ------- | --: |
 | 1 | barlgura | 1 |
 | 2 | 1d4 shadow demon | 2 |
-| 3-4 | chasme | 3 |`;
+| 3-4 | chasme | 3 |
+Other working examples:
+• Weapon (maul or warhammer)
+• Armor (light or medium)
+• Armor (heavy but not plate)
+• Weapon (any melee weapon without the special property)
+• Weapon (any weapon with the heavy property without the special property)`;
 // endregion
 
 class FeatConverter extends BaseConverter {

--- a/js/converter.js
+++ b/js/converter.js
@@ -234,7 +234,7 @@ class CreatureConverter extends BaseConverter {
 		ConverterUiUtil.renderSideMenuDivider($wrpSidebar);
 	}
 
-	handleParse (input, cbOutput, cbWarning, isAppend) {
+	handleParse (input, cbOutput, cbWarning, isAppend, verboseWarnings) {
 		const opts = {
 			cbWarning,
 			cbOutput: (obj, append, prop) => cbOutput(obj, append, prop || this.prop),
@@ -374,7 +374,7 @@ class SpellConverter extends BaseConverter {
 		$wrpSidebar.empty();
 	}
 
-	handleParse (input, cbOutput, cbWarning, isAppend) {
+	handleParse (input, cbOutput, cbWarning, isAppend, verboseWarnings) {
 		const opts = {
 			cbWarning,
 			cbOutput: (obj, append, prop) => cbOutput(obj, append, prop || this.prop),
@@ -429,7 +429,7 @@ class ItemConverter extends BaseConverter {
 		$wrpSidebar.empty();
 	}
 
-	handleParse (input, cbOutput, cbWarning, isAppend) {
+	handleParse (input, cbOutput, cbWarning, isAppend, verboseWarnings) {
 		const opts = {
 			cbWarning,
 			cbOutput: (obj, append, prop) => cbOutput(obj, append, prop || this.prop),
@@ -438,6 +438,7 @@ class ItemConverter extends BaseConverter {
 			isTitleCase: this._state.isTitleCase,
 			source: this._state.source,
 			page: this._state.page,
+			verboseWarnings,
 		};
 
 		switch (this._state.mode) {
@@ -490,7 +491,7 @@ class FeatConverter extends BaseConverter {
 		$wrpSidebar.empty();
 	}
 
-	handleParse (input, cbOutput, cbWarning, isAppend) {
+	handleParse (input, cbOutput, cbWarning, isAppend, verboseWarnings) {
 		const opts = {
 			cbWarning,
 			cbOutput: (obj, append, prop) => cbOutput(obj, append, prop || this.prop),
@@ -540,7 +541,7 @@ class TableConverter extends BaseConverter {
 		$wrpSidebar.empty();
 	}
 
-	handleParse (input, cbOutput, cbWarning, isAppend) {
+	handleParse (input, cbOutput, cbWarning, isAppend, verboseWarnings) {
 		const opts = {
 			cbWarning,
 			cbOutput: (obj, append, prop) => cbOutput(obj, append, prop || this.prop),
@@ -828,6 +829,7 @@ class ConverterUi extends BaseComponent {
 							this.doCleanAndOutput.bind(this),
 							this.showWarning.bind(this),
 							isAppend || i !== 0, // always clear the output for the first non-append chunk, then append
+							this._state.verboseWarnings,
 						);
 					});
 
@@ -951,6 +953,7 @@ ConverterUi._DEFAULT_STATE = {
 	inputSeparator: "===",
 	renderTextEachTime: true,
 	printWarningsToConsole: true,
+	verboseWarnings: false,
 };
 
 async function doPageInit () {

--- a/js/converter.js
+++ b/js/converter.js
@@ -832,6 +832,10 @@ class ConverterUi extends BaseComponent {
 							isAppend || i !== 0, // always clear the output for the first non-append chunk, then append
 						);
 					});
+
+				if (!this._state.renderTextEachTime) {
+					this.doRenderOutput();
+				}
 			});
 		};
 
@@ -884,6 +888,8 @@ class ConverterUi extends BaseComponent {
 	showWarning (text) {
 		$(`#lastWarnings`).show().append(`<div>[Warning] ${text}</div>`);
 		this._editorOut.resize();
+
+		if (this._state.printWarningsToConsole) console.warn(text);
 	}
 
 	doCleanAndOutput (obj, append, prop) {
@@ -905,6 +911,13 @@ class ConverterUi extends BaseComponent {
 
 			this._state.hasAppended = false;
 		}
+
+		if (this._state.renderTextEachTime) {
+			this.doRenderOutput();
+		}
+	}
+
+	doRenderOutput () {
 		const propToString = prop => `"${prop}": [\n\t`
 			+ this._outProps[prop]
 				.join(",\n")
@@ -938,6 +951,8 @@ ConverterUi._DEFAULT_STATE = {
 	converter: "Creature",
 	sourceJson: "",
 	inputSeparator: "===",
+	renderTextEachTime: true,
+	printWarningsToConsole: true,
 };
 
 async function doPageInit () {

--- a/js/converterutils.js
+++ b/js/converterutils.js
@@ -862,8 +862,12 @@ class EntryConvert {
 
 	static finalizeEntry (entry) {
 		if (entry.type === "table") {
+			// Convert dices
+			entry.colLabels[0] = DiceConvert.getTaggedEntry(entry.colLabels[0]);
+			entry.rows.map(row => row.map(cell => DiceConvert.getTaggedEntry(cell)));
+
 			let allNumbers = true;
-			// Center number only columns if it's the first column
+			// Center number/dice only columns if it's the first column
 			for (let i = 0; i < entry.rows.length; i++) {
 				const row = entry.rows[i];
 				if (!(

--- a/js/converterutils.js
+++ b/js/converterutils.js
@@ -450,7 +450,7 @@ class DiceConvert {
 		}
 
 		// re-tag + format dice
-		str = str.replace(/(\s*[-+]\s*)?(([1-9]\d*)?d([1-9]\d*)(\s*?[-+×x*÷/]\s*?(\d,\d|\d)+(\.\d+)?)?)+(?:\s*\+\s*\bPB\b)/gi, (...m) => {
+		str = str.replace(/(\s*[-+]\s*)?(([1-9]\d*)?d([1-9]\d*)(\s*?[-+×x*÷/]\s*?(\d,\d|\d)+(\.\d+)?)?)+(?:\s*\+\s*\bPB\b)?/gi, (...m) => {
 			const expanded = m[0].replace(/([^0-9d.,PB])/gi, " $1 ").replace(/\s+/g, " ");
 			return `{@dice ${expanded}}`;
 		});

--- a/js/render.js
+++ b/js/render.js
@@ -5819,7 +5819,20 @@ Renderer.item = {
 	},
 
 	_createSpecificVariants_hasRequiredProperty (baseItem, genericVariant) {
-		return genericVariant.requires.some(req => Object.entries(req).every(([k, v]) => baseItem[k] === v));
+		return genericVariant.requires.some(req => Object.entries(req).every(([k, v]) => {
+			if (baseItem[k] === v) return true;
+			// for matching only some of an array value, like for item properties
+			if (v.includes) {
+				if (v.includes instanceof Array) {
+					return (baseItem[k] instanceof Array 
+						? baseItem[k].find(it => v.includes.includes(it)) 
+						: v.includes.includes(baseItem[k])
+					);
+				}
+				return baseItem[k] instanceof Array ? baseItem[k].find(it => v.includes === it) : v.includes === baseItem[k];
+			}
+			return false;
+		}));
 	},
 
 	_createSpecificVariants_hasExcludedProperty (baseItem, genericVariant) {


### PR DESCRIPTION
Main changes:
- Text converters outputs proper JSON with elements put in the various prop categories, meaning generic variants for items now work
- The item text converter recognizes way more patterns in the subcategory, for example: `Weapon (any piercing weapon with the light property)` or `Armor (heavy but not plate)`. More examples in the sample text for the item converter. In general:
  - Support for generic exceptions (`except plate armor`, `except longswords`) (yes, it handles plurals too)
  - Support for lists of base items (`shortsword, longsword, or dagger`)
  - Support for property requirements, both positive and negative (and both) `with the light property`, `without the heavy property`
  - Support of base items being the main damage categories (`piercing weapon`, `blunt`, `bludgeoning`, `bladed`, etc.)
  - Support for `melee weapon` / `ranged weapon`, which can be combined with the other parameters
  - Disabled itemGroup output as there was no easy way to make it include an items list, and it didn't work for now
- Markdown tables are recognized in the entries now, and dice columns are recognized inside them.
- More options, mainly for debug. Also way faster when converting large amounts of elements by avoiding to rerender the text for every element converted, which can also be toggled as an option for debug purposes.
- Dice pattern conversion was fixed, as it always expected "+ PB" to have a match and didn't work without 

Also, the JSON schema was technically changed, as generic variant item requirements can now have an "includes" field, like this:
```JSON
"requires": [
  {
    "sword": true,
      "property": {
        "includes": [
        "L",
        "F"
        ]
    }
  }
]
```
I am not sure how to update the schema to account for that, though.